### PR TITLE
feat: add 3d orbital hero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
-import { Mail, Phone, Linkedin, Github, ExternalLink } from "lucide-react";
-import { motion } from "framer-motion";
-import Image from "next/image";
+import { Linkedin, Github, ExternalLink } from "lucide-react";
 import OrbitalHero from "@/components/OrbitalHero";
-import IllustratedOrbit from "@/components/IllustratedOrbit";
-import InteractiveOrbit from "@/components/InteractiveOrbit";
 
 
 export default function Page() {
@@ -180,8 +176,8 @@ function Hero({ links }: { links: any }) {
           </div>
         </div>
 
-        {/* right: interactive scene */}
-        <InteractiveOrbit />
+        {/* right: 3D orbital hero */}
+        <OrbitalHero />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- replace placeholder orbit graphic with OrbitalHero to render a 3D planet and orbiting satellite on the landing page
- clean up unused imports in page component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689817279d448324b6f94cf8804cd211