### PR TITLE
feat: add 3d orbital hero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
-import { Mail, Phone, Linkedin, Github, ExternalLink } from "lucide-react";
-import { motion } from "framer-motion";
-import Image from "next/image";
+import { Linkedin, Github, ExternalLink } from "lucide-react";
 import OrbitalHero from "@/components/OrbitalHero";
-import IllustratedOrbit from "@/components/IllustratedOrbit";
-import InteractiveOrbit from "@/components/InteractiveOrbit";
 
 
 export default function Page() {
@@ -180,8 +176,8 @@ function Hero({ links }: { links: any }) {
           </div>
         </div>
 
-        {/* right: interactive scene */}
-        <InteractiveOrbit />
+        {/* right: 3D orbital hero */}
+        <OrbitalHero />
       </div>
     </section>
   );

--- a/components/OrbitalHero.tsx
+++ b/components/OrbitalHero.tsx
@@ -1,21 +1,20 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { Suspense, useMemo } from "react";
-import { Canvas, useFrame } from "@react-three/fiber";
-import { OrbitControls, Stars } from "@react-three/drei";
+import { Suspense } from "react";
+import { Canvas, useFrame, useLoader } from "@react-three/fiber";
+import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import { useRef } from "react";
 
 // --- Planet
 function Planet() {
-  const mat = useMemo(
-    () => new THREE.MeshStandardMaterial({ color: "#1d4ed8", metalness: 0.2, roughness: 0.4 }),
-    []
-  );
+  const texture = useLoader(THREE.TextureLoader, "/planet.png");
+  texture.colorSpace = THREE.SRGBColorSpace;
   return (
-    <mesh castShadow receiveShadow material={mat}>
+    <mesh castShadow receiveShadow>
       <sphereGeometry args={[1.2, 64, 64]} />
+      <meshStandardMaterial map={texture} metalness={0.2} roughness={0.8} />
     </mesh>
   );
 }
@@ -33,35 +32,13 @@ function Satellite() {
 
   return (
     <group ref={groupRef}>
-      <group>
-        <mesh position={[2.1, 0.4, 0]} castShadow>
-          <boxGeometry args={[0.18, 0.18, 0.4]} />
-          <meshStandardMaterial color="#93c5fd" />
+      <Trail width={0.01} length={6} color="#f0f9ff" decay={8}>
+        <mesh position={[2.2, 0.4, 0]} castShadow>
+          <sphereGeometry args={[0.1, 16, 16]} />
+          <meshStandardMaterial color="#e0f2fe" emissive="#93c5fd" emissiveIntensity={0.4} />
         </mesh>
-
-        {/* solar panels */}
-        <mesh position={[2.1, 0.4, -0.35]}>
-          <boxGeometry args={[0.02, 0.5, 0.7]} />
-          <meshStandardMaterial color="#60a5fa" />
-        </mesh>
-        <mesh position={[2.1, 0.4, 0.35]}>
-          <boxGeometry args={[0.02, 0.5, 0.7]} />
-          <meshStandardMaterial color="#60a5fa" />
-        </mesh>
-      </group>
+      </Trail>
     </group>
-  );
-}
-
-// export default Satellite;
-
-// --- Glow ring
-function Halo() {
-  return (
-    <mesh rotation={[1.2, 0, 0]}>
-      <ringGeometry args={[1.6, 1.9, 96]} />
-      <meshBasicMaterial color="#2563eb" transparent opacity={0.25} side={THREE.DoubleSide} />
-    </mesh>
   );
 }
 
@@ -71,7 +48,6 @@ function Scene() {
       <ambientLight intensity={0.4} />
       <directionalLight position={[3, 5, 4]} intensity={1.1} castShadow />
       <Planet />
-      <Halo />
       <Satellite />
       <Stars radius={50} depth={30} count={1200} factor={2} fade />
       <OrbitControls enableZoom={false} enablePan={false} autoRotate autoRotateSpeed={0.3} />


### PR DESCRIPTION
## Summary
- replace placeholder orbit graphic with OrbitalHero to render a 3D planet and orbiting satellite on the landing page
- enhance planet with realistic texture, remove halo ring, and give satellite a subtler light trail

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689817279d448324b6f94cf8804cd211