### PR TITLE
fix: restore header at top

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,9 +99,9 @@ export default function Page() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 text-slate-100 selection:bg-blue-200">
-      <OrbitalHero id="top" className="h-screen rounded-none border-none shadow-none" />
       <Header links={links} />
-      <main className="mx-auto max-w-6xl px-6 pt-24">
+      <OrbitalHero id="top" className="h-screen rounded-none border-none shadow-none" />
+      <main className="mx-auto max-w-6xl px-6">
         <About />
         <Projects projects={projects} />
         <Experience items={experience} />


### PR DESCRIPTION
## Summary
- always render header before hero so it stays pinned to the top

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aaf8af4ac83249d185534b0ce02a4