### PR TITLE
feat: lighten planet color to light blue

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -45,9 +45,9 @@ function Planet() {
       <mesh>
         <sphereGeometry args={[1.48, 64, 64]} />
         <meshToonMaterial
-          color={"#0f1f4b"}                 // deep blue
+          color={"#93c5fd"}                 // light blue tone
           gradientMap={gradient}
-          emissive={"#1f3b8a"}              // subtle inner glow
+          emissive={"#bfdbfe"}              // gentle inner glow
           emissiveIntensity={0.06}
         />
       </mesh>
@@ -55,7 +55,7 @@ function Planet() {
       {/* Atmosphere glow (additive, very subtle) */}
       <mesh scale={1.12}>
         <sphereGeometry args={[1.48, 64, 64]} />
-        <meshBasicMaterial color="#60a5fa" transparent opacity={0.08} blending={THREE.AdditiveBlending} />
+        <meshBasicMaterial color="#bfdbfe" transparent opacity={0.08} blending={THREE.AdditiveBlending} />
       </mesh>
     </group>
   );

--- a/components/OrbitalHero.tsx
+++ b/components/OrbitalHero.tsx
@@ -22,8 +22,8 @@ function useCosmicTexture(size = 1024) {
       size / 2,
       size / 2
     );
-    g.addColorStop(0, "#030711");
-    g.addColorStop(1, "#0f172a");
+    g.addColorStop(0, "#e0f2fe");
+    g.addColorStop(1, "#93c5fd");
     ctx.fillStyle = g;
     ctx.fillRect(0, 0, size, size);
 
@@ -70,7 +70,7 @@ function Planet() {
       <mesh scale={1.1}>
         <sphereGeometry args={[1.2, 64, 64]} />
         <meshBasicMaterial
-          color="#60a5fa"
+          color="#bfdbfe"
           transparent
           opacity={0.08}
           blending={THREE.AdditiveBlending}


### PR DESCRIPTION
## Summary
- restyle interactive planet with light blue body and glow
- shift hero planet texture and atmosphere to soft blue tones

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab35068f88324b346174b10ef5121