### PR TITLE
Expand orbit containers to near fullscreen

### DIFF
--- a/components/IllustratedOrbit.tsx
+++ b/components/IllustratedOrbit.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 export default function IllustratedOrbit() {
   return (
     <div
-      className="relative w-full h-[420px] md:h-[520px] rounded-2xl border shadow-sm
+      className="relative w-full h-[90vh] rounded-2xl border shadow-sm
                  overflow-hidden bg-gradient-to-br from-slate-50 via-white to-blue-50"
       aria-hidden="true"
     >

--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -162,7 +162,7 @@ const R3FCanvas = dynamic(
 export default function InteractiveOrbit() {
   return (
     <div
-      className="relative w-full h-[420px] md:h-[520px] rounded-2xl border shadow-sm overflow-hidden
+      className="relative w-full h-[90vh] rounded-2xl border shadow-sm overflow-hidden
                  bg-gradient-to-br from-[#0a0f1d] via-[#0b1120] to-[#0b1530]"
       aria-hidden="true"
     >

--- a/components/OrbitalHero.tsx
+++ b/components/OrbitalHero.tsx
@@ -139,7 +139,7 @@ export default function OrbitalHero({ className = "", id }: { className?: string
   return (
     <div
       id={id}
-      className={`relative w-full h-[420px] md:h-[520px] rounded-2xl border shadow-sm
+      className={`relative w-full h-[90vh] rounded-2xl border shadow-sm
                  bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 overflow-hidden ${className}`}
       aria-hidden="true"
     >


### PR DESCRIPTION
## Summary
- Replace fixed pixel heights with `h-[90vh]` so orbit animations nearly fill the viewport.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab36491488324b4f182acf2d52b78