### PR TITLE
Adjust animation height to 80vh

### DIFF
--- a/components/IllustratedOrbit.tsx
+++ b/components/IllustratedOrbit.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 export default function IllustratedOrbit() {
   return (
     <div
-      className="relative w-full h-[85vh] rounded-2xl border shadow-sm
+      className="relative w-full h-[80vh] rounded-2xl border shadow-sm
                  overflow-hidden bg-gradient-to-br from-slate-50 via-white to-blue-50"
       aria-hidden="true"
     >

--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -162,7 +162,7 @@ const R3FCanvas = dynamic(
 export default function InteractiveOrbit() {
   return (
     <div
-      className="relative w-full h-[85vh] rounded-2xl border shadow-sm overflow-hidden
+      className="relative w-full h-[80vh] rounded-2xl border shadow-sm overflow-hidden
                  bg-gradient-to-br from-[#0a0f1d] via-[#0b1120] to-[#0b1530]"
       aria-hidden="true"
     >

--- a/components/OrbitalHero.tsx
+++ b/components/OrbitalHero.tsx
@@ -140,7 +140,7 @@ export default function OrbitalHero({ className = "", id }: { className?: string
   return (
     <div
       id={id}
-      className={`relative w-full h-[85vh] rounded-2xl border shadow-sm
+      className={`relative w-full h-[80vh] rounded-2xl border shadow-sm
                  bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 overflow-hidden ${className}`}
       aria-hidden="true"
     >


### PR DESCRIPTION
## Summary
- tweak orbital animation containers to use 80vh height instead of 85vh

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be4735a3883249a421b3d2b0bdad3