### PR TITLE
Add Notion icon with templates page

### DIFF
--- a/app/notion/page.tsx
+++ b/app/notion/page.tsx
@@ -1,0 +1,10 @@
+export default function NotionPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-6 py-20">
+      <h1 className="text-3xl font-semibold mb-4">Notion Templates</h1>
+      <p className="max-w-2xl text-center text-slate-300">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Linkedin, Github, ExternalLink } from "lucide-react";
+import NotionIcon from "@/components/NotionIcon";
 import OrbitalHero from "@/components/OrbitalHero";
 
 
@@ -13,6 +14,7 @@ export default function Page() {
       site: "https://sites.google.com/psu.edu/meeravshah",
       linkedin: "https://www.linkedin.com/in/meeravshah/",
       github: "https://github.com/Meerav29",
+      notion: "/notion",
       resume: "/resume.pdf",
     }),
     []
@@ -139,6 +141,9 @@ function Header({ links }: { links: any }) {
           </a>
           <a href={links.github} aria-label="GitHub" className="p-2 rounded-xl hover:bg-slate-800">
             <Github size={18} />
+          </a>
+          <a href={links.notion} aria-label="Notion" className="p-2 rounded-xl hover:bg-slate-800">
+            <NotionIcon size={18} />
           </a>
           <a
             href={links.resume}

--- a/components/NotionIcon.tsx
+++ b/components/NotionIcon.tsx
@@ -1,0 +1,20 @@
+import { SVGProps } from "react";
+
+export default function NotionIcon({ size = 24, ...props }: SVGProps<SVGSVGElement> & { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <rect x={3} y={3} width={18} height={18} rx={2} ry={2} />
+      <path d="M8 8v8l8-8v8" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add Notion icon linking to templates page
- create placeholder page for future Notion templates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be5f133708324b90244e259785cc3