### PR TITLE
Raise ScrollIndicator icon position

### DIFF
--- a/components/ScrollIndicator.tsx
+++ b/components/ScrollIndicator.tsx
@@ -1,6 +1,6 @@
 export default function ScrollIndicator() {
   return (
-    <div className="pointer-events-none absolute bottom-6 left-1/2 z-20 -translate-x-1/2 text-slate-300">
+    <div className="pointer-events-none absolute bottom-10 left-1/2 z-20 -translate-x-1/2 text-slate-300">
       <div className="flex flex-col items-center gap-2">
         <svg width="28" height="44" viewBox="0 0 28 44" fill="none" aria-hidden="true">
           <rect x="1.25" y="1.25" width="25.5" height="41.5" rx="12.75" stroke="currentColor" strokeWidth="2.5" />


### PR DESCRIPTION
## Summary
- Move ScrollIndicator wrapper from `bottom-6` to `bottom-10` to raise the scroll icon slightly.

## Testing
- `npm run dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9cd21c3c83249ee7e5dd571a5ae1