### PR TITLE
Add hero greeting with typing animation

### DIFF
--- a/components/OrbitalHero.tsx
+++ b/components/OrbitalHero.tsx
@@ -6,6 +6,7 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import ScrollIndicator from "./ScrollIndicator";
+import TypewriterText from "./TypewriterText";
 
 // Generate a starry canvas texture for a more cosmic appearance
 function useCosmicTexture(size = 1024) {
@@ -153,6 +154,19 @@ export default function OrbitalHero({ className = "", id }: { className?: string
       <R3FCanvas className="absolute inset-0" />
       {/* soft vignette */}
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(transparent,rgba(0,0,0,0.35))]" />
+      {/* centered intro text */}
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center mt-12">
+        <h1 className="text-4xl md:text-6xl font-bold mb-2">
+          <TypewriterText text="Hi! I'm Meerav" />
+        </h1>
+        <p className="text-lg md:text-xl text-slate-200">
+          <TypewriterText
+            text="Senior in CS @ Penn State w/ Astro Minor"
+            delay={1500}
+            speed={50}
+          />
+        </p>
+      </div>
       <ScrollIndicator />
     </div>
   );

--- a/components/TypewriterText.tsx
+++ b/components/TypewriterText.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function TypewriterText({
+  text,
+  speed = 80,
+  delay = 0,
+  className = "",
+}: {
+  text: string;
+  speed?: number;
+  delay?: number;
+  className?: string;
+}) {
+  const [display, setDisplay] = useState("");
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined;
+    let interval: NodeJS.Timeout | undefined;
+
+    timeout = setTimeout(() => {
+      let i = 0;
+      interval = setInterval(() => {
+        setDisplay((prev) => prev + text.charAt(i));
+        i += 1;
+        if (i >= text.length && interval) {
+          clearInterval(interval);
+        }
+      }, speed);
+    }, delay);
+
+    return () => {
+      if (timeout) clearTimeout(timeout);
+      if (interval) clearInterval(interval);
+    };
+  }, [text, speed, delay]);
+
+  return (
+    <span className={className}>
+      {display}
+      <span className="border-r-2 border-slate-200 animate-pulse ml-0.5" />
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Overlay hero planet with typed greeting and subheading
- Implement reusable `TypewriterText` component for typewriter effect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf54fcd808324bfa6dd3d0f5ab347