### PR TITLE
Fix hidden planet in hero section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -68,8 +68,8 @@ body {
   }
 }
 
-/* Ensure all decorative layers stay back */
+/* Ensure decorative layers don't intercept clicks */
 .planet-layer, canvas, .stars {
   pointer-events: none;
-  z-index: -10;
+  z-index: 0; /* Keep above page background but behind text */
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -18,7 +18,7 @@ export default function Hero({ id }: { id?: string }) {
       </div>
 
       {/* PLANET / CANVAS */}
-      <div className="absolute inset-0 -z-10 pointer-events-none planet-layer">
+      <div className="absolute inset-0 pointer-events-none planet-layer">
         <PlanetCanvas />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- keep canvas above page background by removing negative z-index
- remove unnecessary negative z-index class from planet layer wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4a1313e08324b0cabf7b25554f37