### PR TITLE
Fix missing scroll indicator in hero section

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import PlanetCanvas from "./PlanetCanvas";
+import ScrollIndicator from "./ScrollIndicator";
 import { Typewriter } from "./Typewriter";
 
 export default function Hero({ id }: { id?: string }) {
@@ -21,6 +22,7 @@ export default function Hero({ id }: { id?: string }) {
       <div className="absolute inset-0 pointer-events-none planet-layer">
         <PlanetCanvas />
       </div>
+      <ScrollIndicator />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Display the scroll indicator by importing and rendering the `ScrollIndicator` component within the hero section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d4cdb6a188324b093d8503f888202