### PR TITLE
feat: add global header and update notion page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,11 +24,13 @@ export const metadata: Metadata = {
 
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import Header from "@/components/Header";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 text-slate-100 selection:bg-blue-200">
+        <Header />
         {children}
         <Analytics />
         <SpeedInsights />

--- a/app/notion/page.tsx
+++ b/app/notion/page.tsx
@@ -1,83 +1,62 @@
 import Image from "next/image";
 
 export default function NotionPage() {
+  const templates = [
+    {
+      title: "Notion Degree Planner Template",
+      image: "/degree-planner-template.png",
+      alt: "Notion Degree Planner template screenshot",
+      link: "#",
+      description:
+        "Plan your degree with ease. Pursuing a 4 year degree? Planning to double major or add a minor? Program planning across disciplines can be a chaotic mess. Use this straightforward template to map out your entire curriculum and make sure you don't miss any requirements.",
+    },
+    {
+      title: "Notes & Reminders Organizer",
+      image: "/notes-reminders-organizer.png",
+      alt: "Notes and reminders organizer screenshot",
+      link: "#",
+      description:
+        "Take too many notes? Try organizing them so they're easier to access and more useful. Use this template to seamlessly categorize notes and reminders into distinct sections—Work, Classes, Research, Projects and more—offering a structured approach to task management.",
+    },
+  ];
+
   return (
-    <div className="min-h-screen px-6 py-20 space-y-24">
-      {/* Degree Planner Template */}
-      <section className="flex flex-col md:flex-row md:items-center md:gap-10">
-        <div className="md:w-1/2">
-          {/* Placeholder image path; add degree-planner-template.png to public/ before deployment */}
-          <Image
-            src="/degree-planner-template.png"
-            alt="Notion Degree Planner template screenshot"
-            width={1200}
-            height={675}
-            className="rounded-lg shadow-lg"
-            priority
-          />
-        </div>
-        <div className="md:w-1/2 mt-6 md:mt-0">
-          <h2 className="text-2xl font-semibold mb-4">Notion Degree Planner Template</h2>
-          <a
-            href="#"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block mb-4 px-4 py-2 bg-white text-slate-900 rounded-md"
-          >
-            Go to FREE Template
-          </a>
-          <p className="text-slate-300">
-            Plan your degree with ease. Pursuing a 4 year degree? Planning to double major or add a minor? Program planning across
-            disciplines can be a chaotic mess. Use this straightforward template to map out your entire curriculum and make sure you
-            don&apos;t miss any requirements.
-          </p>
-        </div>
-      </section>
+    <div className="px-6 py-20 space-y-24">
+      <div className="mx-auto max-w-6xl grid md:grid-cols-2 gap-12">
+        {templates.map((t) => (
+          <section key={t.title} className="flex flex-col">
+            <Image
+              src={t.image}
+              alt={t.alt}
+              width={1200}
+              height={675}
+              className="rounded-lg shadow-lg"
+            />
+            <h2 className="text-2xl font-semibold mt-6 mb-4">{t.title}</h2>
+            <a
+              href={t.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block mb-4 px-4 py-2 bg-white text-slate-900 rounded-md"
+            >
+              Go to FREE Template
+            </a>
+            <p className="text-slate-300">{t.description}</p>
+          </section>
+        ))}
+      </div>
 
-      {/* Notes & Reminders Organizer */}
-      <section className="flex flex-col md:flex-row-reverse md:items-center md:gap-10">
-        <div className="md:w-1/2">
-          {/* Placeholder image path; add notes-reminders-organizer.png to public/ before deployment */}
-          <Image
-            src="/notes-reminders-organizer.png"
-            alt="Notes and reminders organizer screenshot"
-            width={1200}
-            height={675}
-            className="rounded-lg shadow-lg"
-          />
-        </div>
-        <div className="md:w-1/2 mt-6 md:mt-0">
-          <h2 className="text-2xl font-semibold mb-4">Notes &amp; Reminders Organizer</h2>
-          <a
-            href="#"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block mb-4 px-4 py-2 bg-white text-slate-900 rounded-md"
-          >
-            Go to FREE Template
-          </a>
-          <p className="text-slate-300">
-            Take too many notes? Try organizing them so they&apos;re easier to access and more useful. Use this template to seamlessly
-            categorize notes and reminders into distinct sections—Work, Classes, Research, Projects and more—offering a structured
-            approach to task management.
-          </p>
-        </div>
-      </section>
-
-      {/* About section */}
-      <section className="flex flex-col md:flex-row items-center md:items-start md:gap-10">
+      <section className="mx-auto max-w-4xl flex flex-col md:flex-row items-center md:items-start md:gap-10">
         <div className="md:w-2/3">
           <h2 className="text-2xl font-semibold mb-4">Hi, I am Meerav 👋</h2>
           <p className="text-slate-300">
             I am the creator of these Notion templates. I&apos;ve been using Notion for a long time for personal use—everything from
             planning my degree, to taking notes every day in a scratch pad, to coordinating the workloads and timelines in different
             projects that I&apos;m working on. I make templates out of my Notion workspaces to organize my academics and other
-            opportunities. If you have any feedback or questions, please feel free to reach out 😅. This is what AI thinks I
-            look like ;)
+            opportunities. If you have any feedback or questions, please feel free to reach out 😅. This is what AI thinks I look like ;)
           </p>
         </div>
         <div className="mt-6 md:mt-0">
-          {/* Placeholder image path; add meerav-avatar.png to public/ before deployment */}
           <Image
             src="/meerav-avatar.png"
             alt="Cartoon profile picture of Meerav holding a cup"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
-import { Linkedin, Github, ExternalLink } from "lucide-react";
-import Image from "next/image";
+import { ExternalLink } from "lucide-react";
 import Hero from "@/components/Hero";
+import { links } from "@/lib/links";
 
 export default function Page() {
-  const links = useMemo(
-    () => ({
-      email: "meeravshah29@gmail.com",
-      phone: "+1 (814) 280-8312",
-      site: "https://sites.google.com/psu.edu/meeravshah",
-      linkedin: "https://www.linkedin.com/in/meeravshah/",
-      github: "https://github.com/Meerav29",
-      notion: "/notion",
-      resume: "/resume.pdf",
-    }),
-    []
-  );
-
   const projects = [
     {
       title: "Academic Advising Chatbot (College of IST)",
@@ -99,8 +85,7 @@ export default function Page() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 text-slate-100 selection:bg-blue-200">
-      <Header links={links} />
+    <div>
       <Hero id="top" />
       <main className="mx-auto max-w-6xl px-6">
         <About />
@@ -110,48 +95,6 @@ export default function Page() {
         <Contact links={links} />
       </main>
       <Footer />
-    </div>
-  );
-}
-
-function Header({ links }: { links: any }) {
-  return (
-    <div className="sticky top-0 w-full z-50 backdrop-blur bg-slate-950/60 border-b border-white/10">
-      <nav className="mx-auto max-w-6xl px-6 py-3 flex items-center justify-between text-slate-100">
-        <a href="#top" className="font-semibold tracking-tight text-slate-100">
-          Meerav Shah
-        </a>
-        <div className="hidden md:flex gap-6 text-sm">
-          {[
-            ["About", "#about"],
-            ["Projects", "#projects"],
-            ["Experience", "#experience"],
-            ["Skills", "#skills"],
-            ["Contact", "#contact"],
-          ].map(([label, href]) => (
-            <a key={label} href={href as string} className="hover:text-blue-400 transition-colors">
-              {label}
-            </a>
-          ))}
-        </div>
-        <div className="flex items-center gap-3">
-          <a href={links.linkedin} aria-label="LinkedIn" className="p-2 rounded-xl hover:bg-slate-800">
-            <Linkedin size={18} />
-          </a>
-          <a href={links.github} aria-label="GitHub" className="p-2 rounded-xl hover:bg-slate-800">
-            <Github size={18} />
-          </a>
-          <a href={links.notion} aria-label="Notion" className="p-2 rounded-xl hover:bg-slate-800">
-             <Image src="/notion-w.png" alt="Notion logo" width={18} height={18} />
-          </a>
-          <a
-            href={links.resume}
-            className="inline-flex items-center gap-2 text-sm rounded-xl border border-white/10 px-3 py-1.5 bg-white text-slate-900 hover:bg-slate-200"
-          >
-            Resume <ExternalLink size={14} />
-          </a>
-        </div>
-      </nav>
     </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,45 @@
+import Image from "next/image";
+import { Linkedin, Github, ExternalLink } from "lucide-react";
+import { links } from "@/lib/links";
+
+export default function Header() {
+  return (
+    <div className="sticky top-0 w-full z-50 backdrop-blur bg-slate-950/60 border-b border-white/10">
+      <nav className="mx-auto max-w-6xl px-6 py-3 flex items-center justify-between text-slate-100">
+        <a href="/" className="font-semibold tracking-tight text-slate-100">
+          Meerav Shah
+        </a>
+        <div className="hidden md:flex gap-6 text-sm">
+          {[
+            ["About", "/#about"],
+            ["Projects", "/#projects"],
+            ["Experience", "/#experience"],
+            ["Skills", "/#skills"],
+            ["Contact", "/#contact"],
+          ].map(([label, href]) => (
+            <a key={label} href={href} className="hover:text-blue-400 transition-colors">
+              {label}
+            </a>
+          ))}
+        </div>
+        <div className="flex items-center gap-3">
+          <a href={links.linkedin} aria-label="LinkedIn" className="p-2 rounded-xl hover:bg-slate-800">
+            <Linkedin size={18} />
+          </a>
+          <a href={links.github} aria-label="GitHub" className="p-2 rounded-xl hover:bg-slate-800">
+            <Github size={18} />
+          </a>
+          <a href={links.notion} aria-label="Notion" className="p-2 rounded-xl hover:bg-slate-800">
+            <Image src="/notion-w.png" alt="Notion logo" width={18} height={18} />
+          </a>
+          <a
+            href={links.resume}
+            className="inline-flex items-center gap-2 text-sm rounded-xl border border-white/10 px-3 py-1.5 bg-white text-slate-900 hover:bg-slate-200"
+          >
+            Resume <ExternalLink size={14} />
+          </a>
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,0 +1,9 @@
+export const links = {
+  email: "meeravshah29@gmail.com",
+  phone: "+1 (814) 280-8312",
+  site: "https://sites.google.com/psu.edu/meeravshah",
+  linkedin: "https://www.linkedin.com/in/meeravshah/",
+  github: "https://github.com/Meerav29",
+  notion: "/notion",
+  resume: "/resume.pdf",
+};


### PR DESCRIPTION
## Summary
- extract shared header component and include in global layout
- centralize site links and apply site-wide gradient
- present Notion templates as aesthetic card grid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5d86e5d08324bf397f07933362f1