### PR TITLE
Use dark gray background and fade hero into page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --background: #0f172a; /* dark slate */
+  --background: #1a1a1a; /* dark gray */
   --foreground: #f8fafc; /* slate-50 */
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ import Header from "@/components/Header";
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-blue-950 text-slate-100 selection:bg-blue-200">
+      <body className="min-h-screen text-slate-100 selection:bg-blue-200">
         <Header />
         {children}
         <Analytics />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -22,6 +22,8 @@ export default function Hero({ id }: { id?: string }) {
       <div className="absolute inset-0 pointer-events-none planet-layer">
         <PlanetCanvas />
       </div>
+      {/* fade from animation to page background */}
+      <div className="absolute inset-0 pointer-events-none z-10 bg-gradient-to-b from-transparent to-[var(--background)]" />
       <ScrollIndicator />
     </section>
   );


### PR DESCRIPTION
## Summary
- switch global background to dark gray for consistent dark mode
- remove layout gradient and rely on new color
- add gradient overlay in Hero so animation blends into the page background

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e87e094f88324a8d304a0c727ce61