### PR TITLE
feat: add theme toggle and color scheme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,8 +3,23 @@
 @tailwind utilities;
 
 :root {
-  --background: #1a1a1a; /* dark gray */
-  --foreground: #f8fafc; /* slate-50 */
+  --background: #F6F8FA;
+  --foreground: #24292F;
+  --muted: #57606A;
+  --card: #FFFFFF;
+  --accent: #0969DA;
+  --border: #d0d7de;
+  --link-hover: #054DA3;
+}
+
+.dark {
+  --background: #0D1117;
+  --foreground: #E6EDF3;
+  --muted: #8B949E;
+  --card: #161B22;
+  --accent: #58A6FF;
+  --border: #30363d;
+  --link-hover: #1F6FEB;
 }
 
 html, body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,15 +25,18 @@ export const metadata: Metadata = {
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Header from "@/components/Header";
+import ThemeProvider from "@/components/ThemeProvider";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen text-slate-100 selection:bg-blue-200">
-        <Header />
-        {children}
-        <Analytics />
-        <SpeedInsights />
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-background text-foreground selection:bg-accent">
+        <ThemeProvider>
+          <Header />
+          {children}
+          <Analytics />
+          <SpeedInsights />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/notion/page.tsx
+++ b/app/notion/page.tsx
@@ -37,11 +37,11 @@ export default function NotionPage() {
               href={t.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block mb-4 px-4 py-2 bg-white text-slate-900 rounded-md"
+              className="inline-block mb-4 px-4 py-2 bg-card text-foreground border border-border rounded-md"
             >
               Go to FREE Template
             </a>
-            <p className="text-slate-300">{t.description}</p>
+            <p className="text-muted">{t.description}</p>
           </section>
         ))}
       </div>
@@ -49,7 +49,7 @@ export default function NotionPage() {
       <section className="mx-auto max-w-4xl flex flex-col md:flex-row items-center md:items-start md:gap-10">
         <div className="md:w-2/3">
           <h2 className="text-2xl font-semibold mb-4">Hi, I am Meerav 👋</h2>
-          <p className="text-slate-300">
+          <p className="text-muted">
             I am the creator of these Notion templates. I&apos;ve been using Notion for a long time for personal use—everything from
             planning my degree, to taking notes every day in a scratch pad, to coordinating the workloads and timelines in different
             projects that I&apos;m working on. I make templates out of my Notion workspaces to organize my academics and other

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,10 +101,10 @@ export default function Page() {
 
 function Section({ id, title, children }: any) {
   return (
-    <section id={id} className="py-14 md:py-20 border-t border-white/10">
+    <section id={id} className="py-14 md:py-20 border-t border-border">
       <div className="flex items-end justify-between mb-8">
         <h2 className="text-2xl md:text-3xl font-semibold tracking-tight">{title}</h2>
-        <a href="#top" className="text-sm text-slate-400 hover:text-slate-200">
+        <a href="#top" className="text-sm text-muted hover:text-link-hover">
           Back to top
         </a>
       </div>
@@ -116,7 +116,7 @@ function Section({ id, title, children }: any) {
 function About() {
   return (
     <Section id="about" title="About">
-      <p className="text-slate-300 leading-relaxed max-w-3xl">
+      <p className="text-muted leading-relaxed max-w-3xl">
         I’m an undergraduate senior in Computer Science at Penn State, minoring in Astrophysics. I build practical, minimal tools—
         from advising assistants that free up faculty time to UAV analytics that make flight safer in icing conditions. I care about
         clean design, clear impact, and shipping real things.
@@ -133,18 +133,18 @@ function Projects({ projects }: { projects: any[] }) {
           <a
             key={p.title}
             href={(p.link as string) || "#"}
-            className="group rounded-2xl border border-white/10 p-6 bg-slate-900/50 hover:bg-slate-800 transition-colors"
+            className="group rounded-2xl border border-border p-6 bg-card hover:bg-card transition-colors"
           >
             <div className="flex items-start justify-between gap-6">
-              <h3 className="text-lg font-medium leading-snug text-[#64FFDA]">{p.title}</h3>
+              <h3 className="text-lg font-medium leading-snug text-accent">{p.title}</h3>
               <ExternalLink size={16} className="shrink-0 opacity-70 group-hover:opacity-100" />
             </div>
-            <p className="mt-3 text-slate-300 text-sm leading-relaxed">{p.summary}</p>
+            <p className="mt-3 text-muted text-sm leading-relaxed">{p.summary}</p>
             <div className="mt-4 flex flex-wrap gap-2">
                 {p.tags?.map((t: string) => (
                   <span
                     key={t}
-                    className="text-xs text-[#64FFDA] rounded-full border border-[#64FFDA] px-2 py-1 bg-slate-900/40"
+                    className="text-xs text-accent rounded-full border border-accent px-2 py-1 bg-transparent"
                   >
                     {t}
                   </span>
@@ -164,17 +164,17 @@ function Experience({ items }: { items: any[] }) {
         {items.map((job) => (
           <div
             key={job.org + job.time}
-            className="rounded-2xl border border-white/10 p-6 bg-slate-900/50"
+            className="rounded-2xl border border-border p-6 bg-card"
           >
             <div className="flex items-center justify-between gap-4">
               <div>
-                  <h3 className="font-medium text-[#64FFDA]">
-                    {job.role} · <span className="text-[#64FFDA]">{job.org}</span>
+                  <h3 className="font-medium text-accent">
+                    {job.role} · <span className="text-accent">{job.org}</span>
                   </h3>
-                <div className="text-sm text-slate-400">{job.time}</div>
+                <div className="text-sm text-muted">{job.time}</div>
               </div>
             </div>
-              <ul className="mt-3 space-y-2 list-disc pl-5 text-[#64FFDA] text-sm">
+              <ul className="mt-3 space-y-2 list-disc pl-5 text-accent text-sm">
                 {job.points.map((pt: string) => (
                   <li key={pt}>{pt}</li>
                 ))}
@@ -193,7 +193,7 @@ function Skills({ items }: { items: string[] }) {
         {items.map((s) => (
               <span
                 key={s}
-                className="text-sm text-[#64FFDA] rounded-full border border-[#64FFDA] px-3 py-1.5 bg-slate-900/40"
+                className="text-sm text-accent rounded-full border border-accent px-3 py-1.5 bg-transparent"
               >
                 {s}
               </span>
@@ -206,9 +206,9 @@ function Skills({ items }: { items: string[] }) {
 function Contact({ links }: { links: any }) {
   return (
     <Section id="contact" title="Get in touch">
-      <div className="rounded-2xl border p-6 bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 text-white">
+      <div className="rounded-2xl border border-border p-6 bg-gradient-to-br from-accent to-link-hover text-background">
         <h3 className="text-xl font-semibold">Let’s build something.</h3>
-        <p className="mt-2 text-white/80 max-w-2xl">
+        <p className="mt-2 text-background opacity-80 max-w-2xl">
           I’m open to research collaborations, product work, and internships in AI, aerospace, and ed-tech.
         </p>
 
@@ -223,18 +223,18 @@ function Contact({ links }: { links: any }) {
             name="email"
             placeholder="Your email"
             required
-            className="flex-1 rounded-xl px-4 py-2 text-slate-900 placeholder-slate-500"
+            className="flex-1 rounded-xl px-4 py-2 bg-background text-foreground placeholder-muted"
           />
           <input
             type="text"
             name="message"
             placeholder="Say hello..."
             required
-            className="flex-1 rounded-xl px-4 py-2 text-slate-900 placeholder-slate-500"
+            className="flex-1 rounded-xl px-4 py-2 bg-background text-foreground placeholder-muted"
           />
           <button
             type="submit"
-            className="rounded-xl bg-white text-slate-900 px-4 py-2 text-sm hover:bg-slate-100 transition-colors"
+            className="rounded-xl bg-background text-foreground px-4 py-2 text-sm hover:bg-card transition-colors"
           >
             Send
           </button>
@@ -244,19 +244,19 @@ function Contact({ links }: { links: any }) {
         <div className="mt-6 flex flex-wrap gap-3 text-sm">
           <a
             href={`mailto:${links.email}`}
-            className="rounded-xl border border-white/30 px-4 py-2 hover:bg-white/10"
+            className="rounded-xl border border-background px-4 py-2 hover:bg-background text-background"
           >
             Email Me
           </a>
           <a
             href={links.linkedin}
-            className="rounded-xl border border-white/30 px-4 py-2 hover:bg-white/10"
+            className="rounded-xl border border-background px-4 py-2 hover:bg-background text-background"
           >
             LinkedIn
           </a>
           <a
             href={links.site}
-            className="rounded-xl border border-white/30 px-4 py-2 hover:bg-white/10"
+            className="rounded-xl border border-background px-4 py-2 hover:bg-background text-background"
           >
             Current Site
           </a>
@@ -269,8 +269,8 @@ function Contact({ links }: { links: any }) {
 
 function Footer() {
   return (
-    <footer className="mt-16 border-t border-white/10">
-      <div className="mx-auto max-w-6xl px-6 py-6 text-sm text-slate-400 flex flex-col md:flex-row items-center justify-between gap-3">
+    <footer className="mt-16 border-t border-border">
+      <div className="mx-auto max-w-6xl px-6 py-6 text-sm text-muted flex flex-col md:flex-row items-center justify-between gap-3">
         <span>© {new Date().getFullYear()} Meerav Shah</span>
         <span className="opacity-80">Built with Next.js + Tailwind · Minimal, blue/black/white.</span>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,13 @@
 import Image from "next/image";
 import { Linkedin, Github, ExternalLink } from "lucide-react";
 import { links } from "@/lib/links";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
   return (
-    <div className="sticky top-0 w-full z-50 backdrop-blur bg-slate-950/60 border-b border-white/10">
-      <nav className="mx-auto max-w-6xl px-6 py-3 flex items-center justify-between text-slate-100">
-        <a href="/" className="font-semibold tracking-tight text-slate-100">
+    <div className="sticky top-0 w-full z-50 backdrop-blur bg-background border-b border-border">
+      <nav className="mx-auto max-w-6xl px-6 py-3 flex items-center justify-between text-foreground">
+        <a href="/" className="font-semibold tracking-tight text-foreground">
           Meerav Shah
         </a>
         <div className="hidden md:flex gap-6 text-sm">
@@ -17,24 +18,26 @@ export default function Header() {
             ["Skills", "/#skills"],
             ["Contact", "/#contact"],
           ].map(([label, href]) => (
-            <a key={label} href={href} className="hover:text-blue-400 transition-colors">
+            <a key={label} href={href} className="hover:text-link-hover transition-colors">
               {label}
             </a>
           ))}
         </div>
         <div className="flex items-center gap-3">
-          <a href={links.linkedin} aria-label="LinkedIn" className="p-2 rounded-xl hover:bg-slate-800">
+          <ThemeToggle />
+          <a href={links.linkedin} aria-label="LinkedIn" className="p-2 rounded-xl hover:bg-card">
             <Linkedin size={18} />
           </a>
-          <a href={links.github} aria-label="GitHub" className="p-2 rounded-xl hover:bg-slate-800">
+          <a href={links.github} aria-label="GitHub" className="p-2 rounded-xl hover:bg-card">
             <Github size={18} />
           </a>
-          <a href={links.notion} aria-label="Notion" className="p-2 rounded-xl hover:bg-slate-800">
-            <Image src="/notion-w.png" alt="Notion logo" width={18} height={18} />
+          <a href={links.notion} aria-label="Notion" className="p-2 rounded-xl hover:bg-card">
+            <Image src="/notion-w.png" alt="Notion logo" width={18} height={18} className="dark:block hidden" />
+            <Image src="/notion-b.png" alt="Notion logo" width={18} height={18} className="dark:hidden block" />
           </a>
           <a
             href={links.resume}
-            className="inline-flex items-center gap-2 text-sm rounded-xl border border-white/10 px-3 py-1.5 bg-white text-slate-900 hover:bg-slate-200"
+            className="inline-flex items-center gap-2 text-sm rounded-xl border border-accent px-3 py-1.5 bg-accent text-background hover:bg-link-hover"
           >
             Resume <ExternalLink size={14} />
           </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero({ id }: { id?: string }) {
         <h1 className="text-6xl md:text-7xl font-extrabold tracking-tight">
           Hi! I&apos;m Meerav
         </h1>
-        <p className="mt-3 text-lg md:text-xl text-slate-200">
+        <p className="mt-3 text-lg md:text-xl text-muted">
           Senior in CS @ Penn State · Astro minor
         </p>
         <Typewriter text="Building AI tools for education and space tech" />

--- a/components/IllustratedOrbit.tsx
+++ b/components/IllustratedOrbit.tsx
@@ -4,8 +4,8 @@ import Image from "next/image";
 export default function IllustratedOrbit() {
   return (
     <div
-      className="relative w-full h-[80vh] rounded-2xl border shadow-sm
-                 overflow-hidden bg-gradient-to-br from-slate-50 via-white to-blue-50"
+      className="relative w-full h-[80vh] rounded-2xl border border-border shadow-sm
+                 overflow-hidden bg-card"
       aria-hidden="true"
     >
       {/* vignette */}

--- a/components/ScrollIndicator.tsx
+++ b/components/ScrollIndicator.tsx
@@ -1,6 +1,6 @@
 export default function ScrollIndicator() {
   return (
-    <div className="pointer-events-none absolute bottom-14 left-1/2 z-20 -translate-x-1/2 text-slate-300">
+    <div className="pointer-events-none absolute bottom-14 left-1/2 z-20 -translate-x-1/2 text-muted">
       <div className="flex flex-col items-center gap-2">
         <svg width="28" height="44" viewBox="0 0 28 44" fill="none" aria-hidden="true">
           <rect x="1.25" y="1.25" width="25.5" height="41.5" rx="12.75" stroke="currentColor" strokeWidth="2.5" />

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  toggleTheme: () => {},
+});
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme") as Theme | null;
+    let initial: Theme = stored || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    window.localStorage.setItem("theme", next);
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}
+

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "./ThemeProvider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className="p-2 rounded-xl hover:bg-card"
+    >
+      {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,24 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        muted: "var(--muted)",
+        card: "var(--card)",
+        accent: "var(--accent)",
+        border: "var(--border)",
+        "link-hover": "var(--link-hover)",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- implement global light/dark color variables and Tailwind theme tokens
- add custom theme provider with toggle and integrate it into header
- refactor pages to use accent and background tokens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5914a2e48324922281d76713d0fd