### PR TITLE
Remove Typewriter from hero

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,7 +2,6 @@
 
 import PlanetCanvas from "./PlanetCanvas";
 import ScrollIndicator from "./ScrollIndicator";
-import { Typewriter } from "./Typewriter";
 
 export default function Hero({ id }: { id?: string }) {
   return (
@@ -15,7 +14,7 @@ export default function Hero({ id }: { id?: string }) {
         <p className="mt-3 text-lg md:text-xl text-muted">
           Senior in CS @ Penn State · Astro minor
         </p>
-        <Typewriter text="Building AI tools for education and space tech" />
+        {/* <Typewriter text="Building AI tools for education and space tech" /> */}
       </div>
 
       {/* PLANET / CANVAS */}


### PR DESCRIPTION
## Summary
- remove Typewriter import and component so hero only shows header and subheader

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9ea885248324b86fafd84998c855