### PR TITLE
chore: adjust base colors in planet canvas

### DIFF
--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -46,7 +46,7 @@ function useCosmicTexture(accent: string, size = 1024) {
 function Planet() {
   const { accent, background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#1f2937" : accent;
+  const base = theme === "light" ? "#333333" : accent;
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -86,7 +86,7 @@ function Planet() {
 function Satellite() {
   const { accent } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#1f2937" : accent;
+  const base = theme === "light" ? "#333333" : accent;
   const groupRef = useRef<THREE.Group>(null!);
 
   useFrame(({ clock }) => {


### PR DESCRIPTION
## Summary
- use `#333333` as the light-mode base color in planet and satellite renders

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9eab928c832496420f58b9a9cad5