### PR TITLE
feat: darken planet in light mode

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -33,7 +33,7 @@ function Planet() {
   const gradient = useToonGradient(4);
   const { accent, background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#1f2937" : accent;
+  const base = theme === "light" ? "#141414" : accent;
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -81,7 +81,7 @@ function Satellite({
 }: { radius?: number; speed?: number; tiltDeg?: number }) {
   const { accent } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#1f2937" : accent;
+  const base = theme === "light" ? "#141414" : accent;
   const sat = useRef<THREE.Group>(null!);
   const tilt = THREE.MathUtils.degToRad(tiltDeg);
 
@@ -138,7 +138,7 @@ function Satellite({
 function Scene() {
   const { accent, background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#1f2937" : accent;
+  const base = theme === "light" ? "#141414" : accent;
   return (
     <>
       {/* flattering, minimal lighting */}

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -46,7 +46,7 @@ function useCosmicTexture(accent: string, size = 1024) {
 function Planet() {
   const { accent, background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#333333" : accent;
+  const base = theme === "light" ? "#141414" : accent;
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -86,7 +86,7 @@ function Planet() {
 function Satellite() {
   const { accent } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#333333" : accent;
+  const base = theme === "light" ? "#141414" : accent;
   const groupRef = useRef<THREE.Group>(null!);
 
   useFrame(({ clock }) => {


### PR DESCRIPTION
## Summary
- darken planet base colors in light mode for both animated scenes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa1f0619c83248e8c3a3b2af56e45