### PR TITLE
Improve light mode readability and darken planet

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ function Projects({ projects }: { projects: any[] }) {
             className="group rounded-2xl border border-border p-6 bg-card hover:bg-card transition-colors"
           >
             <div className="flex items-start justify-between gap-6">
-              <h3 className="text-lg font-medium leading-snug text-white">{p.title}</h3>
+              <h3 className="text-lg font-medium leading-snug text-black dark:text-white">{p.title}</h3>
               <ExternalLink size={16} className="shrink-0 opacity-70 group-hover:opacity-100" />
             </div>
             <p className="mt-3 text-muted text-sm leading-relaxed">{p.summary}</p>
@@ -144,7 +144,7 @@ function Projects({ projects }: { projects: any[] }) {
                 {p.tags?.map((t: string) => (
                   <span
                     key={t}
-                    className="text-xs text-white rounded-full border border-white px-2 py-1 bg-transparent"
+                    className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
                   >
                     {t}
                   </span>
@@ -168,13 +168,13 @@ function Experience({ items }: { items: any[] }) {
           >
             <div className="flex items-center justify-between gap-4">
               <div>
-                  <h3 className="font-medium text-white">
-                    {job.role} · <span className="text-white">{job.org}</span>
+                  <h3 className="font-medium text-black dark:text-white">
+                    {job.role} · <span className="text-black dark:text-white">{job.org}</span>
                   </h3>
                 <div className="text-sm text-muted">{job.time}</div>
               </div>
             </div>
-              <ul className="mt-3 space-y-2 list-disc pl-5 text-white text-sm">
+              <ul className="mt-3 space-y-2 list-disc pl-5 text-black dark:text-white text-sm">
                 {job.points.map((pt: string) => (
                   <li key={pt}>{pt}</li>
                 ))}

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -46,7 +46,7 @@ function useCosmicTexture(accent: string, size = 1024) {
 function Planet() {
   const { accent, background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#141414" : accent;
+  const base = theme === "light" ? "#000000" : accent;
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -86,7 +86,7 @@ function Planet() {
 function Satellite() {
   const { accent } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "light" ? "#141414" : accent;
+  const base = theme === "light" ? "#000000" : accent;
   const groupRef = useRef<THREE.Group>(null!);
 
   useFrame(({ clock }) => {


### PR DESCRIPTION
## Summary
- Ensure project and experience sections use black text in light mode and white in dark mode
- Darken planet and satellite base color in light mode while keeping gradient

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1117d0a70832495e9ba1169accc5e