### PR TITLE
feat: darken planet color

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -6,7 +6,6 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import { useThemeColors, lighten, darken } from "../lib/theme";
-import { useTheme } from "./ThemeProvider";
 
 /* --- Utilities --- */
 function useToonGradient(steps = 4) {
@@ -31,9 +30,8 @@ function useToonGradient(steps = 4) {
 /* --- Planet: toon sphere + thin outline + soft atmosphere --- */
 function Planet() {
   const gradient = useToonGradient(4);
-  const { accent, background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#141414" : accent;
+  const { background } = useThemeColors();
+  const base = "#000000";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -63,7 +61,7 @@ function Planet() {
       <mesh scale={1.12}>
         <sphereGeometry args={[1.48, 64, 64]} />
         <meshBasicMaterial
-          color={lighten(base, 0.25)}
+          color={lighten(base, 0.1)}
           transparent
           opacity={0.08}
           blending={THREE.AdditiveBlending}
@@ -79,9 +77,7 @@ function Satellite({
   speed = 0.35,
   tiltDeg = 18,
 }: { radius?: number; speed?: number; tiltDeg?: number }) {
-  const { accent } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#141414" : accent;
+  const base = "#000000";
   const sat = useRef<THREE.Group>(null!);
   const tilt = THREE.MathUtils.degToRad(tiltDeg);
 
@@ -136,18 +132,17 @@ function Satellite({
 
 /* --- Scene --- */
 function Scene() {
-  const { accent, background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#141414" : accent;
+  const { background } = useThemeColors();
+  const base = "#000000";
   return (
     <>
       {/* flattering, minimal lighting */}
       <hemisphereLight
-        color={lighten(base, 0.6)}
+        color={lighten(base, 0.3)}
         groundColor={darken(background, 0.6)}
         intensity={0.35}
       />
-      <directionalLight position={[3, 4, 2]} intensity={0.9} color={lighten(base, 0.2)} />
+      <directionalLight position={[3, 4, 2]} intensity={0.9} color={lighten(base, 0.15)} />
 
       <Planet />
       <Satellite />

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -6,10 +6,9 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import { useThemeColors, lighten, darken } from "../lib/theme";
-import { useTheme } from "./ThemeProvider";
 
-// Generate a starry canvas texture using the current accent color.
-function useCosmicTexture(accent: string, size = 1024) {
+// Generate a starry canvas texture using the provided base color.
+function useCosmicTexture(base: string, size = 1024) {
   return useMemo(() => {
     const canvas = document.createElement("canvas");
     canvas.width = canvas.height = size;
@@ -23,8 +22,8 @@ function useCosmicTexture(accent: string, size = 1024) {
       size / 2,
       size / 2
     );
-    g.addColorStop(0, lighten(accent, 0.35));
-    g.addColorStop(1, accent);
+    g.addColorStop(0, lighten(base, 0.1));
+    g.addColorStop(1, base);
     ctx.fillStyle = g;
     ctx.fillRect(0, 0, size, size);
 
@@ -39,14 +38,13 @@ function useCosmicTexture(accent: string, size = 1024) {
     }
 
     return new THREE.CanvasTexture(canvas);
-  }, [accent, size]);
+  }, [base, size]);
 }
 
 // --- Planet: cosmic sphere with subtle glow
 function Planet() {
-  const { accent, background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#000000" : accent;
+  const { background } = useThemeColors();
+  const base = "#000000";
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -72,7 +70,7 @@ function Planet() {
       <mesh scale={1.1}>
         <sphereGeometry args={[1.2, 64, 64]} />
         <meshBasicMaterial
-          color={lighten(base, 0.25)}
+          color={lighten(base, 0.1)}
           transparent
           opacity={0.08}
           blending={THREE.AdditiveBlending}
@@ -84,9 +82,7 @@ function Planet() {
 
 // --- Tiny satellite orbiting
 function Satellite() {
-  const { accent } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#000000" : accent;
+  const base = "#000000";
   const groupRef = useRef<THREE.Group>(null!);
 
   useFrame(({ clock }) => {


### PR DESCRIPTION
## Summary
- Render the planet and satellite using a fixed black base color
- Darken atmospheric glow and star texture for a deeper, blacker appearance
- Subdue scene lighting to match the darker planet

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2084e47188324a5cf59c1fd6fbbc9