### PR TITLE
Revert merge causing useTheme build error

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -30,9 +30,8 @@ function useToonGradient(steps = 4) {
 /* --- Planet: toon sphere + thin outline + soft atmosphere --- */
 function Planet() {
   const gradient = useToonGradient(4);
-  const { accent, background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "light" ? "#000000" : accent;
+  const { background } = useThemeColors();
+  const base = "#000000";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {


### PR DESCRIPTION
## Summary
- revert merge that introduced unresolved `useTheme` reference

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a298c9a16483248b2e73386886e53b