### PR TITLE
feat: restore dark blue planet color

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -6,6 +6,7 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import { useThemeColors, lighten, darken } from "../lib/theme";
+import { useTheme } from "./ThemeProvider";
 
 /* --- Utilities --- */
 function useToonGradient(steps = 4) {
@@ -31,7 +32,8 @@ function useToonGradient(steps = 4) {
 function Planet() {
   const gradient = useToonGradient(4);
   const { background } = useThemeColors();
-  const base = "#000000";
+  const { theme } = useTheme();
+  const base = theme === "dark" ? "#080B12" : "#000000";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -133,7 +135,8 @@ function Satellite({
 /* --- Scene --- */
 function Scene() {
   const { background } = useThemeColors();
-  const base = "#000000";
+  const { theme } = useTheme();
+  const base = theme === "dark" ? "#080B12" : "#000000";
   return (
     <>
       {/* flattering, minimal lighting */}


### PR DESCRIPTION
## Summary
- ensure interactive orbit uses dark blue planet in dark mode
- apply theme-based base color logic for orbit scene

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: interrupted)

------
https://chatgpt.com/codex/tasks/task_e_68a90558250483248423b1cf53aa9bd3