### PR TITLE
Swap planet colors for light and dark modes

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -33,7 +33,7 @@ function Planet() {
   const gradient = useToonGradient(4);
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#000000" : "#080B12";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -136,7 +136,7 @@ function Satellite({
 function Scene() {
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#000000" : "#080B12";
   return (
     <>
       {/* flattering, minimal lighting */}

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -45,7 +45,7 @@ function useCosmicTexture(base: string, size = 1024) {
 function Planet() {
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#000000" : "#080B12";
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -59,7 +59,7 @@ function Planet() {
       <mesh scale={1.03} castShadow receiveShadow>
         <sphereGeometry args={[1.2, 64, 64]} />
         <meshBasicMaterial
-          color={theme === "dark" ? "#080B12" : darken(background, 0.6)}
+          color={theme === "dark" ? "#000000" : darken(background, 0.6)}
           side={THREE.BackSide}
         />
       </mesh>


### PR DESCRIPTION
## Summary
- swap base planet colors so dark mode uses black and light mode uses navy
- adjust planet outline color for dark mode

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a907eba098832496d7335e605797e2