### PR TITLE
Swap planet gradients and default to dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className="min-h-screen bg-background text-foreground selection:bg-accent">
         <ThemeProvider>
           <Header />

--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -33,7 +33,7 @@ function Planet() {
   const gradient = useToonGradient(4);
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#58A6FF" : "#000000";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -45,7 +45,10 @@ function Planet() {
       {/* Outline (very thin) */}
       <mesh scale={1.015}>
         <sphereGeometry args={[1.5, 64, 64]} />
-        <meshBasicMaterial color={darken(background, 0.6)} side={THREE.BackSide} />
+        <meshBasicMaterial
+          color={theme === "dark" ? darken(background, 0.6) : "#000000"}
+          side={THREE.BackSide}
+        />
       </mesh>
 
       {/* Toon body */}
@@ -136,7 +139,7 @@ function Satellite({
 function Scene() {
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#58A6FF" : "#000000";
   return (
     <>
       {/* flattering, minimal lighting */}

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -45,7 +45,7 @@ function useCosmicTexture(base: string, size = 1024) {
 function Planet() {
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#080B12" : "#000000";
+  const base = theme === "dark" ? "#58A6FF" : "#000000";
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 
@@ -59,7 +59,7 @@ function Planet() {
       <mesh scale={1.03} castShadow receiveShadow>
         <sphereGeometry args={[1.2, 64, 64]} />
         <meshBasicMaterial
-          color={theme === "dark" ? "#080B12" : darken(background, 0.6)}
+          color={theme === "dark" ? darken(background, 0.6) : "#000000"}
           side={THREE.BackSide}
         />
       </mesh>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -10,7 +10,7 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: "light",
+  theme: "dark",
   toggleTheme: () => {},
 });
 
@@ -19,12 +19,12 @@ export function useTheme() {
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setTheme] = useState<Theme>("dark");
 
   useEffect(() => {
     const mql = window.matchMedia("(prefers-color-scheme: dark)");
     const stored = window.localStorage.getItem("theme") as Theme | null;
-    const initial: Theme = stored || (mql.matches ? "dark" : "light");
+    const initial: Theme = stored || "dark";
     setTheme(initial);
     document.documentElement.classList.toggle("dark", initial === "dark");
 


### PR DESCRIPTION
## Summary
- render planet with black gradient in light mode and light blue gradient in dark mode
- start app in dark mode by default

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a907eba098832496d7335e605797e2