### PR TITLE
Use dark default theme and adjust planet gradient

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className="min-h-screen bg-background text-foreground selection:bg-accent">
         <ThemeProvider>
           <Header />

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -45,7 +45,7 @@ function useCosmicTexture(base: string, size = 1024) {
 function Planet() {
   const { background } = useThemeColors();
   const { theme } = useTheme();
-  const base = theme === "dark" ? "#000000" : "#080B12";
+  const base = theme === "dark" ? "#8EC5FC" : "#000000";
   const texture = useCosmicTexture(base);
   const planetRef = useRef<THREE.Group>(null!);
 

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -10,7 +10,7 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: "light",
+  theme: "dark",
   toggleTheme: () => {},
 });
 
@@ -19,12 +19,12 @@ export function useTheme() {
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setTheme] = useState<Theme>("dark");
 
   useEffect(() => {
     const mql = window.matchMedia("(prefers-color-scheme: dark)");
     const stored = window.localStorage.getItem("theme") as Theme | null;
-    const initial: Theme = stored || (mql.matches ? "dark" : "light");
+    const initial: Theme = stored || "dark";
     setTheme(initial);
     document.documentElement.classList.toggle("dark", initial === "dark");
 


### PR DESCRIPTION
## Summary
- Default the site to dark mode by setting initial theme and HTML class
- Reverse planet gradient colors so light mode uses black and dark mode uses light blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a931bd24b0832485ff854dbf88cfe1