### PR TITLE
feat: add project detail pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import { ExternalLink } from "lucide-react";
 import Hero from "@/components/Hero";
 import { links } from "@/lib/links";
+import { projects } from "@/lib/projects";
 
 export default function Page() {
-  const projects = [
-    {
-      title: "Academic Advising Chatbot (College of IST)",
-      tags: ["LLM", "OpenAI API", "Python", "Prompting", "Research", "Machine Learning"],
-      summary:
-        "Built an advising assistant that answers routine queries and supports course planning; reduced advising load and improved answer depth.",
-      link: "https://github.com/Meerav29?tab=repositories",
-    },
-    {
-      title: "Autonomous UAV Icing Research (MCREU)",
-      tags: ["UAV", "Torque/RPM", "Data Analysis", "Research", "Machine Learning"],
-      summary:
-        "Studied how cloud/icing conditions affect UAV performance using onboard telemetry; proposed real-time mitigation algorithms.",
-      link: "#",
-    },
-    {
-      title: "Autonomous Vehicle Behavior Study (HTI Lab)",
-      tags: ["Simulation", "STISIM3", "Human Factors"],
-      summary:
-        "Designed driving-sim scenarios to analyze interactions between AVs and human-driven vehicles at varying market penetrations.",
-      link: "#",
-    },
-    {
-      title: "NASA Big Idea Challenge — Lunar Regolith Construction",
-      tags: ["Aerospace", "Systems Engineering", "Leadership"],
-      summary:
-        "Led a 15-member team exploring inflatable tech to 3D-print structures on the Moon using lunar regolith.",
-      link: "#",
-    },
-  ];
 
   const experience = [
     {
@@ -130,9 +102,9 @@ function Projects({ projects }: { projects: any[] }) {
     <Section id="projects" title="Featured Projects">
       <div className="grid md:grid-cols-2 gap-6">
         {projects.map((p) => (
-          <a
-            key={p.title}
-            href={(p.link as string) || "#"}
+          <Link
+            key={p.slug}
+            href={`/projects/${p.slug}`}
             className="group rounded-2xl border border-border p-6 bg-card hover:bg-card transition-colors"
           >
             <div className="flex items-start justify-between gap-6">
@@ -141,16 +113,16 @@ function Projects({ projects }: { projects: any[] }) {
             </div>
             <p className="mt-3 text-muted text-sm leading-relaxed">{p.summary}</p>
             <div className="mt-4 flex flex-wrap gap-2">
-                {p.tags?.map((t: string) => (
-                  <span
-                    key={t}
-                    className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
-                  >
-                    {t}
-                  </span>
-                ))}
+              {p.tags?.map((t: string) => (
+                <span
+                  key={t}
+                  className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
+                >
+                  {t}
+                </span>
+              ))}
             </div>
-          </a>
+          </Link>
         ))}
       </div>
     </Section>

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import { projects } from "@/lib/projects";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+
+export default function ProjectPage({ params }: { params: { slug: string } }) {
+  const project = projects.find((p) => p.slug === params.slug);
+  if (!project) notFound();
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-14">
+      <Link href="/" className="text-sm text-muted hover:text-link-hover">
+        &larr; Back
+      </Link>
+      <h1 className="mt-4 text-3xl font-semibold text-black dark:text-white">
+        {project.title}
+      </h1>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {project.tags.map((t) => (
+          <span
+            key={t}
+            className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
+          >
+            {t}
+          </span>
+        ))}
+      </div>
+      <p className="mt-6 text-muted leading-relaxed">{project.content}</p>
+      {project.source && (
+        <a
+          href={project.source}
+          className="mt-6 inline-flex items-center gap-1 text-sm text-link-hover hover:underline"
+        >
+          View source <ExternalLink size={16} />
+        </a>
+      )}
+    </main>
+  );
+}
+
+export function generateStaticParams() {
+  return projects.map((p) => ({ slug: p.slug }));
+}
+

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,49 @@
+export type Project = {
+  slug: string;
+  title: string;
+  tags: string[];
+  summary: string;
+  content: string;
+  source?: string;
+};
+
+export const projects: Project[] = [
+  {
+    slug: "academic-advising-chatbot",
+    title: "Academic Advising Chatbot (College of IST)",
+    tags: ["LLM", "OpenAI API", "Python", "Prompting", "Research", "Machine Learning"],
+    summary:
+      "Built an advising assistant that answers routine queries and supports course planning; reduced advising load and improved answer depth.",
+    content:
+      "Built an advising assistant that answers routine queries and supports course planning. Integrated the OpenAI API with carefully designed prompts and a Python backend, reducing advising load while increasing answer depth.",
+    source: "https://github.com/Meerav29?tab=repositories",
+  },
+  {
+    slug: "autonomous-uav-icing",
+    title: "Autonomous UAV Icing Research (MCREU)",
+    tags: ["UAV", "Torque/RPM", "Data Analysis", "Research", "Machine Learning"],
+    summary:
+      "Studied how cloud/icing conditions affect UAV performance using onboard telemetry; proposed real-time mitigation algorithms.",
+    content:
+      "Studied how cloud and icing conditions affect UAV performance using onboard torque and RPM telemetry. Analyzed collected data and proposed real-time mitigation algorithms to maintain control authority during adverse conditions.",
+  },
+  {
+    slug: "autonomous-vehicle-behavior",
+    title: "Autonomous Vehicle Behavior Study (HTI Lab)",
+    tags: ["Simulation", "STISIM3", "Human Factors"],
+    summary:
+      "Designed driving-sim scenarios to analyze interactions between AVs and human-driven vehicles at varying market penetrations.",
+    content:
+      "Designed STISIM3 driving simulation scenarios to analyze interactions between autonomous vehicles and human-driven traffic at varying market penetrations. Evaluated driver responses and traffic flow metrics across conditions.",
+  },
+  {
+    slug: "nasa-big-idea-lunar-regolith",
+    title: "NASA Big Idea Challenge — Lunar Regolith Construction",
+    tags: ["Aerospace", "Systems Engineering", "Leadership"],
+    summary:
+      "Led a 15-member team exploring inflatable tech to 3D-print structures on the Moon using lunar regolith.",
+    content:
+      "Led a 15-member team exploring inflatable technology to 3D-print structures on the Moon using lunar regolith. Coordinated research, systems engineering, and outreach for the NASA Big Idea Challenge.",
+  },
+];
+


### PR DESCRIPTION
## Summary
- move project metadata into a dedicated `lib/projects` module
- link featured project cards to individual detail pages
- add dynamic project detail page with tags and optional source link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a93afb9c088324a688b989368132f9