### PR TITLE
Ensure planet and satellite render black in light mode

### DIFF
--- a/components/InteractiveOrbit.tsx
+++ b/components/InteractiveOrbit.tsx
@@ -6,7 +6,6 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
 import { useThemeColors, lighten, darken } from "../lib/theme";
-import { useTheme } from "./ThemeProvider";
 
 /* --- Utilities --- */
 function useToonGradient(steps = 4) {
@@ -32,8 +31,7 @@ function useToonGradient(steps = 4) {
 function Planet() {
   const gradient = useToonGradient(4);
   const { background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "dark" ? "#000000" : "#080B12";
+  const base = "#000000";
   const planetRef = useRef<THREE.Group>(null!);
 
   useFrame((_, dt) => {
@@ -95,9 +93,9 @@ function Satellite({
     }
   });
 
-  const trail = lighten(base, 0.3);
-  const body = lighten(base, 0.6);
-  const panel = lighten(base, 0.4);
+  const trail = base;
+  const body = base;
+  const panel = base;
 
   return (
     <group>
@@ -135,8 +133,7 @@ function Satellite({
 /* --- Scene --- */
 function Scene() {
   const { background } = useThemeColors();
-  const { theme } = useTheme();
-  const base = theme === "dark" ? "#000000" : "#080B12";
+  const base = "#000000";
   return (
     <>
       {/* flattering, minimal lighting */}

--- a/components/PlanetCanvas.tsx
+++ b/components/PlanetCanvas.tsx
@@ -4,7 +4,7 @@ import { Suspense, useMemo, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, Stars, Trail } from "@react-three/drei";
 import * as THREE from "three";
-import { useThemeColors, lighten, darken } from "../lib/theme";
+import { useThemeColors, darken } from "../lib/theme";
 import { useTheme } from "./ThemeProvider";
 
 // Generate a starry canvas texture using the provided base color.
@@ -22,7 +22,7 @@ function useCosmicTexture(base: string, size = 1024) {
       size / 2,
       size / 2
     );
-    g.addColorStop(0, lighten(base, 0.1));
+    g.addColorStop(0, base);
     g.addColorStop(1, base);
     ctx.fillStyle = g;
     ctx.fillRect(0, 0, size, size);
@@ -74,7 +74,7 @@ function Planet() {
       <mesh scale={1.1}>
         <sphereGeometry args={[1.2, 64, 64]} />
         <meshBasicMaterial
-          color={lighten(base, 0.1)}
+          color={base}
           transparent
           opacity={0.08}
           blending={THREE.AdditiveBlending}
@@ -96,9 +96,9 @@ function Satellite() {
     }
   });
 
-  const trail = lighten(base, 0.3);
-  const body = lighten(base, 0.6);
-  const emissive = lighten(base, 0.4);
+  const trail = base;
+  const body = base;
+  const emissive = base;
 
   return (
     <group ref={groupRef}>


### PR DESCRIPTION
## Summary
- Force InteractiveOrbit planet and satellite to always use deep black base color
- Remove lightening of PlanetCanvas satellite and texture so objects stay black in light theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa498b1f588324a685d7de0d1a9512