### PR TITLE
feat: add research page and navigation

### DIFF
--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { research } from "@/lib/research";
+
+export const metadata = {
+  title: "Research — Meerav Shah",
+};
+
+export default function ResearchPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-14">
+      <h1 className="text-3xl font-semibold text-black dark:text-white">Research</h1>
+      <p className="mt-4 text-muted">Selected research outputs and publications.</p>
+      <div className="mt-8 grid gap-6">
+        {research.map((item) => (
+          <div
+            key={item.title}
+            className="rounded-2xl border border-border p-6 bg-card"
+          >
+            <h2 className="text-lg font-medium text-black dark:text-white">
+              {item.title}
+            </h2>
+            <p className="mt-2 text-muted text-sm leading-relaxed">
+              {item.summary}
+            </p>
+            {item.link && (
+              <Link
+                href={item.link}
+                className="mt-2 inline-flex items-center gap-1 text-sm text-link-hover hover:underline"
+              >
+                Learn more <ExternalLink size={16} />
+              </Link>
+            )}
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,5 +3,6 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: "https://meeravshah.vercel.app/", lastModified: new Date() },
+    { url: "https://meeravshah.vercel.app/research", lastModified: new Date() },
   ];
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,6 +14,7 @@ export default function Header() {
           {[
             ["About", "/#about"],
             ["Projects", "/#projects"],
+            ["Research", "/research"],
             ["Experience", "/#experience"],
             ["Skills", "/#skills"],
             ["Contact", "/#contact"],

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -1,0 +1,26 @@
+export type ResearchItem = {
+  title: string;
+  summary: string;
+  link?: string;
+};
+
+export const research: ResearchItem[] = [
+  {
+    title: "Adaptive Tutoring Agents",
+    summary:
+      "Investigated AI tutors that personalize explanations and feedback using large language models.",
+    link: "https://example.com/adaptive-tutoring",
+  },
+  {
+    title: "UAV Icing Detection",
+    summary:
+      "Analyzed propeller telemetry to identify icing events and propose real-time mitigation algorithms.",
+    link: "https://example.com/uav-icing",
+  },
+  {
+    title: "Driver Behavior in Mixed Autonomy Traffic",
+    summary:
+      "Designed driving-simulator studies exploring interactions between human drivers and autonomous vehicles.",
+  },
+];
+


### PR DESCRIPTION
## Summary
- add Research link to header navigation
- create dedicated research page with sample entries
- include research in sitemap

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab4777fef88324839b1b844a0ef95a