### PR TITLE
Add icon-only button support and render logo buttons in research cards

### DIFF
--- a/components/ResearchCard.tsx
+++ b/components/ResearchCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { Linkedin } from "lucide-react";
 import { useRef, useState } from "react";
 import Lightbox from "./Lightbox";
 import Tag from "./Tag";
@@ -86,10 +87,27 @@ export default function ResearchCard({ item }: { item: ResearchItem }) {
             {item.links.slides && <Button href={item.links.slides}>Slides</Button>}
             {item.links.poster && <Button href={item.links.poster}>Poster</Button>}
             {item.links.website && <Button href={item.links.website}>Website</Button>}
-            {item.links.notion && <Button href={item.links.notion}>Notion</Button>}
+            {item.links.notion && (
+              <Button href={item.links.notion} ariaLabel="Notion" variant="icon">
+                <Image
+                  src="/notion-w.png"
+                  alt="Notion logo"
+                  width={18}
+                  height={18}
+                  className="dark:block hidden"
+                />
+                <Image
+                  src="/notion-b.png"
+                  alt="Notion logo"
+                  width={18}
+                  height={18}
+                  className="dark:hidden block"
+                />
+              </Button>
+            )}
             {item.links.linkedin && (
-              <Button href={item.links.linkedin} variant="subtle">
-                LinkedIn
+              <Button href={item.links.linkedin} variant="icon" ariaLabel="LinkedIn">
+                <Linkedin size={18} />
               </Button>
             )}
           </div>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -4,15 +4,28 @@ import type { ReactNode } from "react";
 export type ButtonProps = {
   href: string;
   children: ReactNode;
-  variant?: "primary" | "secondary" | "subtle";
+  variant?: "primary" | "secondary" | "subtle" | "icon";
+  ariaLabel?: string;
+  className?: string;
 };
 
-export function Button({ href, children, variant = "secondary" }: ButtonProps) {
-  const base = "inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium border transition focus:outline-none focus-visible:ring-2 ring-accent";
+export function Button({
+  href,
+  children,
+  variant = "secondary",
+  ariaLabel,
+  className,
+}: ButtonProps) {
+  const base =
+    "inline-flex items-center gap-2 rounded-xl text-sm font-medium border transition focus:outline-none focus-visible:ring-2 ring-accent";
   const variants: Record<string, string> = {
-    primary: "bg-accent text-white hover:opacity-90 border-transparent",
-    secondary: "bg-transparent text-foreground hover:bg-foreground/5 border-border",
-    subtle: "bg-transparent text-muted hover:bg-foreground/5 border-transparent",
+    primary:
+      "px-4 py-2 bg-accent text-white hover:opacity-90 border-transparent",
+    secondary:
+      "px-4 py-2 bg-transparent text-foreground hover:bg-foreground/5 border-border",
+    subtle:
+      "px-4 py-2 bg-transparent text-muted hover:bg-foreground/5 border-transparent",
+    icon: "p-2 bg-transparent text-foreground hover:bg-foreground/5 border-border",
   };
 
   return (
@@ -20,7 +33,8 @@ export function Button({ href, children, variant = "secondary" }: ButtonProps) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={`${base} ${variants[variant]}`}
+      aria-label={ariaLabel}
+      className={`${base} ${variants[variant]} ${className ?? ""}`}
     >
       {children}
     </Link>


### PR DESCRIPTION
## Summary
- allow `Button` to accept `ariaLabel`/`className` and add an `icon` variant
- render Notion and LinkedIn links as logo-only buttons with accessible labels in research cards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add53e3b288324969f8eaa2fc5c338