### PR TITLE
Restore hero intro on landing page

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -14,26 +14,36 @@ export default function Hero({ id }: { id?: string }) {
 
       {/* Left-aligned content over the canvas */}
       <div className="relative z-20 flex h-full items-center">
-        <div className="pl-6 md:pl-12 pr-6 max-w-xl">
-          <div className="animate-[float_6s_ease-in-out_infinite]">
-            <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">Hi I&apos;m Meerav!</h1>
-            <p className="mt-3 text-base md:text-lg text-muted">Senior in CS @ Penn State • Astro minor</p>
-          </div>
+          <div className="pl-6 md:pl-12 pr-6 max-w-xl">
+            <div className="animate-[float_6s_ease-in-out_infinite]">
+              <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-black dark:text-white">
+                Hi I&apos;m Meerav!
+              </h1>
+              <p className="mt-3 text-base md:text-lg text-muted">
+                Senior in CS @ Penn State • Astro minor
+              </p>
+            </div>
 
-          <p className="mt-6 text-sm md:text-base leading-relaxed text-muted max-w-prose">
-            I&apos;m an undergraduate senior in Computer Science at Penn State, minoring in Astrophysics. I build practical, minimal tools — from advising assistants that free up faculty time to UAV analytics that make flight safer in icing conditions. I care about clean design, clear impact, and shipping real things.
-          </p>
+            <p className="mt-6 text-sm md:text-base leading-relaxed text-muted max-w-prose">
+              I&apos;m an undergraduate senior in Computer Science at Penn State, minoring in Astrophysics. I build practical, minimal tools—from advising assistants that free up faculty time to UAV analytics that make flight safer in icing conditions. I care about clean design, clear impact, and shipping real things.
+            </p>
 
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-            <Link href="/research" className="rounded-xl border border-border bg-card px-4 py-2 text-sm hover:bg-card/80 transition-colors">
-              Research Outputs
-            </Link>
-            <Link href="/experience" className="rounded-xl border border-border bg-card px-4 py-2 text-sm hover:bg-card/80 transition-colors">
-              Work Experience
-            </Link>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/research"
+                className="rounded-xl border border-border bg-card px-4 py-2 text-sm hover:bg-card/80 transition-colors"
+              >
+                Research Outputs
+              </Link>
+              <Link
+                href="/experience"
+                className="rounded-xl border border-border bg-card px-4 py-2 text-sm hover:bg-card/80 transition-colors"
+              >
+                Work Experience
+              </Link>
+            </div>
           </div>
         </div>
-      </div>
 
       {/* Scroll affordance */}
       <ScrollIndicator />


### PR DESCRIPTION
## Summary
- ensure landing page hero displays intro text, about snippet, and links alongside planet animation

## Testing
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b08efe05d48324832c40618a01b19a