### PR TITLE
Add ScrollReveal component and CSS; animate sections, project cards, and contact links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -95,3 +95,41 @@ body {
   pointer-events: none;
   z-index: 0; /* Keep above page background but behind text */
 }
+
+/* Scroll reveal animation */
+.scroll-reveal {
+  --reveal-delay: 0ms;
+  --reveal-distance: 24px;
+  opacity: 0;
+  transform: translate3d(0, var(--reveal-distance), 0) scale(0.985);
+  filter: blur(6px);
+  transition:
+    opacity 650ms cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay),
+    transform 650ms cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay),
+    filter 650ms ease-out var(--reveal-delay);
+  will-change: opacity, transform, filter;
+}
+
+.scroll-reveal.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  filter: blur(0);
+}
+
+.scroll-reveal-section {
+  will-change: opacity, transform;
+}
+
+.scroll-reveal-card {
+  height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal,
+  .scroll-reveal.is-visible {
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ExternalLink, Mail, Linkedin, Github, FileText } from "lucide-react";
 import Hero from "@/components/Hero";
+import ScrollReveal from "@/components/ScrollReveal";
 import { links } from "@/lib/links";
 import { projects } from "@/lib/projects";
 
@@ -21,15 +22,17 @@ export default function Page() {
 
 function Section({ id, title, children }: any) {
   return (
-    <section id={id} className="py-14 md:py-20 border-t border-border">
-      <div className="flex items-end justify-between mb-8">
-        <h2 className="text-2xl md:text-3xl font-semibold tracking-tight">{title}</h2>
-        <a href="#top" className="text-sm text-muted hover:text-link-hover">
-          Back to top
-        </a>
-      </div>
-      {children}
-    </section>
+    <ScrollReveal className="scroll-reveal-section">
+      <section id={id} className="py-14 md:py-20 border-t border-border">
+        <div className="flex items-end justify-between mb-8">
+          <h2 className="text-2xl md:text-3xl font-semibold tracking-tight">{title}</h2>
+          <a href="#top" className="text-sm text-muted hover:text-link-hover">
+            Back to top
+          </a>
+        </div>
+        {children}
+      </section>
+    </ScrollReveal>
   );
 }
 
@@ -37,28 +40,29 @@ function Projects({ projects }: { projects: any[] }) {
   return (
     <Section id="projects" title="Featured Projects">
       <div className="grid md:grid-cols-2 gap-6">
-        {projects.map((p) => (
-          <Link
-            key={p.slug}
-            href={`/projects/${p.slug}`}
-            className="group rounded-2xl border border-border p-6 bg-card hover:bg-card transition-colors"
-          >
-            <div className="flex items-start justify-between gap-6">
-              <h3 className="text-lg font-medium leading-snug text-black dark:text-white">{p.title}</h3>
-              <ExternalLink size={16} className="shrink-0 opacity-70 group-hover:opacity-100" />
-            </div>
-            <p className="mt-3 text-muted text-sm leading-relaxed">{p.summary}</p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {p.tags?.map((t: string) => (
-                <span
-                  key={t}
-                  className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
-                >
-                  {t}
-                </span>
-              ))}
-            </div>
-          </Link>
+        {projects.map((p, idx) => (
+          <ScrollReveal key={p.slug} delay={90 * idx} distance={18}>
+            <Link
+              href={`/projects/${p.slug}`}
+              className="group rounded-2xl border border-border p-6 bg-card hover:bg-card transition-colors scroll-reveal-card"
+            >
+              <div className="flex items-start justify-between gap-6">
+                <h3 className="text-lg font-medium leading-snug text-black dark:text-white">{p.title}</h3>
+                <ExternalLink size={16} className="shrink-0 opacity-70 group-hover:opacity-100" />
+              </div>
+              <p className="mt-3 text-muted text-sm leading-relaxed">{p.summary}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {p.tags?.map((t: string) => (
+                  <span
+                    key={t}
+                    className="text-xs text-black dark:text-white rounded-full border border-black dark:border-white px-2 py-1 bg-transparent"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </Link>
+          </ScrollReveal>
         ))}
       </div>
     </Section>
@@ -99,20 +103,21 @@ function Contact({ links }: { links: any }) {
         Graduating May 2026 and actively looking for full-time roles. Open to opportunities in AI, aerospace, and ed-tech — research, product, or engineering.
       </p>
       <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-        {contactLinks.map((link) => (
-          <a
-            key={link.label}
-            href={link.href}
-            target={link.href.startsWith("mailto") ? undefined : "_blank"}
-            rel="noopener noreferrer"
-            className="group flex flex-col gap-3 rounded-2xl border border-border p-5 bg-card hover:border-accent transition-colors"
-          >
-            <div className="text-accent">{link.icon}</div>
-            <div>
-              <div className="text-sm font-medium">{link.label}</div>
-              <div className="text-xs text-muted mt-0.5">{link.value}</div>
-            </div>
-          </a>
+        {contactLinks.map((link, idx) => (
+          <ScrollReveal key={link.label} delay={80 * idx} distance={16}>
+            <a
+              href={link.href}
+              target={link.href.startsWith("mailto") ? undefined : "_blank"}
+              rel="noopener noreferrer"
+              className="group flex flex-col gap-3 rounded-2xl border border-border p-5 bg-card hover:border-accent transition-colors"
+            >
+              <div className="text-accent">{link.icon}</div>
+              <div>
+                <div className="text-sm font-medium">{link.label}</div>
+                <div className="text-xs text-muted mt-0.5">{link.value}</div>
+              </div>
+            </a>
+          </ScrollReveal>
         ))}
       </div>
     </Section>

--- a/components/ScrollReveal.tsx
+++ b/components/ScrollReveal.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { CSSProperties, ReactNode, useEffect, useRef, useState } from "react";
+
+type ScrollRevealProps = {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+  distance?: number;
+  once?: boolean;
+};
+
+export default function ScrollReveal({
+  children,
+  className,
+  delay = 0,
+  distance = 24,
+  once = true,
+}: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReducedMotion) {
+      setIsVisible(true);
+      return;
+    }
+
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          if (once) observer.unobserve(entry.target);
+        } else if (!once) {
+          setIsVisible(false);
+        }
+      },
+      {
+        threshold: 0.2,
+        rootMargin: "0px 0px -8% 0px",
+      },
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [once]);
+
+  const style = {
+    ["--reveal-delay" as string]: `${delay}ms`,
+    ["--reveal-distance" as string]: `${distance}px`,
+  } as CSSProperties;
+
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className={`scroll-reveal ${isVisible ? "is-visible" : ""} ${className ?? ""}`.trim()}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Introduce a lightweight scroll reveal animation to add subtle entrance transitions to page sections and cards for improved polish and perceived performance.
- Respect accessibility preferences by disabling motion when `prefers-reduced-motion` is enabled.

### Description

- Add a new client component `components/ScrollReveal.tsx` that uses `IntersectionObserver` to toggle a `is-visible` class and exposes `delay`, `distance`, and `once` props.  The component sets CSS variables for per-element delays and distances and falls back to visible state when reduced motion is preferred.  
- Update `app/page.tsx` to wrap section headings, project cards, and contact links with `ScrollReveal`, applying staggered `delay` and `distance` values for each item.
- Extend `app/globals.css` with `.scroll-reveal` styles, an `.is-visible` state, helper classes (`.scroll-reveal-section`, `.scroll-reveal-card`), and a `@media (prefers-reduced-motion: reduce)` rule to disable transitions for users who opt out of animations.

### Testing

- Ran TypeScript type check with `tsc --noEmit` and the project typed successfully.  
- Built the Next.js app with `next build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d7f533cc832492e5a7e09154b7e8)