### PR TITLE
New mobile-optimized landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,139 +1,46 @@
-"use client";
-
+// app/page.tsx
 import Link from "next/link";
-import { ExternalLink, Mail, Linkedin, Github, FileText } from "lucide-react";
-import Hero from "@/components/Hero";
-import ScrollReveal from "@/components/ScrollReveal";
+import Hero2 from "@/components/Hero2";
+import { WorkRow } from "@/components/WorkRow";
+import { workItems } from "@/data/work";
 import { links } from "@/lib/links";
-import { projects } from "@/lib/projects";
+
+const featured = workItems.filter((w) => w.featured);
 
 export default function Page() {
   return (
     <div>
-      <Hero id="top" />
-      <main className="mx-auto max-w-6xl px-6">
-        <Projects projects={projects} />
-        <Contact links={links} />
-      </main>
-      <Footer />
-    </div>
-  );
-}
-
-function Section({ id, title, children }: any) {
-  return (
-    <ScrollReveal className="scroll-reveal-section">
-      <section id={id} className="py-14 md:py-20 border-t border-border">
-        <div className="flex items-end justify-between mb-8">
-          <h2 className="text-2xl md:text-3xl font-semibold tracking-tight">{title}</h2>
-          <a href="#top" className="text-sm text-muted hover:text-link-hover">
-            Back to top
-          </a>
-        </div>
-        {children}
-      </section>
-    </ScrollReveal>
-  );
-}
-
-function Projects({ projects }: { projects: any[] }) {
-  return (
-    <Section id="projects" title="Featured Projects">
-      <div className="grid md:grid-cols-2 gap-6">
-        {projects.map((p, idx) => (
-          <ScrollReveal key={p.slug} className="h-full" delay={90 * idx} distance={18}>
-            <Link
-              href={`/projects/${p.slug}`}
-              className="scroll-reveal-card group flex h-full min-h-[17rem] flex-col rounded-[28px] border border-border bg-card p-6 transition-[transform,border-color,box-shadow] duration-300 hover:-translate-y-1 hover:border-accent/30 hover:shadow-[0_22px_50px_-34px_rgba(15,23,42,0.5)]"
-            >
-              <div className="flex flex-1 flex-col">
-                <div className="flex items-start justify-between gap-6">
-                  <h3 className="text-lg font-medium leading-snug text-black dark:text-white">{p.title}</h3>
-                  <ExternalLink size={16} className="mt-1 shrink-0 opacity-70 transition-opacity duration-300 group-hover:opacity-100" />
-                </div>
-                <p className="mt-3 max-w-[52ch] text-sm leading-relaxed text-muted">{p.summary}</p>
-              </div>
-              <div className="mt-5 flex flex-wrap gap-2">
-                {p.tags?.map((t: string) => (
-                  <span
-                    key={t}
-                    className="rounded-full border border-black/80 bg-transparent px-3 py-1 text-xs text-black dark:border-white/80 dark:text-white"
-                  >
-                    {t}
-                  </span>
-                ))}
-              </div>
+      <Hero2 />
+      <main className="mx-auto max-w-3xl px-6 pb-24" id="work">
+        <section>
+          <div className="flex items-baseline justify-between mb-2">
+            <h2 className="text-xs uppercase tracking-widest text-muted/60">Selected Work</h2>
+            <Link href="/work" className="text-xs text-muted hover:text-foreground transition-colors">
+              All work →
             </Link>
-          </ScrollReveal>
-        ))}
-      </div>
-    </Section>
-  );
-}
-
-function Contact({ links }: { links: any }) {
-  const contactLinks = [
-    {
-      icon: <Mail size={20} />,
-      label: "Email",
-      value: links.email,
-      href: `mailto:${links.email}`,
-    },
-    {
-      icon: <Linkedin size={20} />,
-      label: "LinkedIn",
-      value: "@meeravshah",
-      href: links.linkedin,
-    },
-    {
-      icon: <Github size={20} />,
-      label: "GitHub",
-      value: "@Meerav29",
-      href: links.github,
-    },
-    {
-      icon: <FileText size={20} />,
-      label: "Resume",
-      value: "View PDF",
-      href: links.resume,
-    },
-  ];
-
-  return (
-    <Section id="contact" title="Get in touch">
-      <p className="text-muted max-w-2xl mb-8">
-        Graduating May 2026 and actively looking for full-time roles. Open to opportunities in AI, aerospace, and ed-tech — research, product, or engineering.
-      </p>
-      <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-        {contactLinks.map((link, idx) => (
-          <ScrollReveal key={link.label} delay={80 * idx} distance={16}>
-            <a
-              href={link.href}
-              target={link.href.startsWith("mailto") ? undefined : "_blank"}
-              rel="noopener noreferrer"
-              className="group flex flex-col gap-3 rounded-2xl border border-border p-5 bg-card hover:border-accent transition-colors"
-            >
-              <div className="text-accent">{link.icon}</div>
-              <div>
-                <div className="text-sm font-medium">{link.label}</div>
-                <div className="text-xs text-muted mt-0.5">{link.value}</div>
-              </div>
-            </a>
-          </ScrollReveal>
-        ))}
-      </div>
-    </Section>
-  );
-}
-
-
-function Footer() {
-  return (
-    <footer className="mt-16 border-t border-border">
-      <div className="mx-auto max-w-6xl px-6 py-6 text-sm text-muted flex flex-col md:flex-row items-center justify-between gap-3">
-        <span>© {new Date().getFullYear()} Meerav Shah</span>
-        <span className="opacity-80">Built with Next.js + Tailwind · Minimal, blue/black/white.</span>
-      </div>
-    </footer>
+          </div>
+          {featured.map((item) => (
+            <WorkRow key={item.id} item={item} />
+          ))}
+        </section>
+        <section className="mt-16">
+          <h2 className="text-xs uppercase tracking-widest text-muted/60 mb-4">Get in touch</h2>
+          <div className="flex items-center gap-3 text-sm text-muted flex-wrap">
+            <a href={`mailto:${links.email}`} className="hover:text-foreground transition-colors">Email</a>
+            <span className="text-muted/30" aria-hidden="true">·</span>
+            <a href={links.linkedin} target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">LinkedIn</a>
+            <span className="text-muted/30" aria-hidden="true">·</span>
+            <a href={links.github} target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">GitHub</a>
+            <span className="text-muted/30" aria-hidden="true">·</span>
+            <a href={links.resume} target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Resume</a>
+          </div>
+        </section>
+      </main>
+      <footer className="border-t border-border">
+        <div className="mx-auto max-w-3xl px-6 py-6 text-xs text-muted/50">
+          <span>© {new Date().getFullYear()} Meerav Shah</span>
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,32 @@
+// app/work/page.tsx
+import { WorkRow } from "@/components/WorkRow";
+import { workItems } from "@/data/work";
+
+export const metadata = { title: "Work — Meerav Shah" };
+
+const sections: { label: string; category: "industry" | "research" | "early" }[] = [
+  { label: "Industry", category: "industry" },
+  { label: "Research & Leadership", category: "research" },
+  { label: "Early Projects", category: "early" },
+];
+
+export default function WorkPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16 pb-24">
+      <h1 className="text-xs uppercase tracking-widest text-muted/60 mb-12">Work</h1>
+      {sections.map(({ label, category }) => {
+        const items = workItems.filter((w) => w.category === category);
+        return (
+          <section key={category} className="mb-12">
+            <h2 className="text-xs uppercase tracking-widest text-muted/60 mb-4">{label}</h2>
+            <div>
+              {items.map((item) => (
+                <WorkRow key={item.id} item={item} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </main>
+  );
+}

--- a/components/Hero2.tsx
+++ b/components/Hero2.tsx
@@ -9,9 +9,9 @@ export default function Hero2() {
 
   return (
     <div>
-      {/* Mobile: small centered planet up top, text flows below in normal layout */}
-      <section className="relative md:hidden">
-        <div className="relative mx-auto mt-8 h-56 w-full max-w-xs">
+      {/* Mobile: large centered planet, vertically centered in the viewport */}
+      <section className="relative flex min-h-[calc(100vh-57px)] flex-col justify-center md:hidden">
+        <div className="relative mx-auto h-80 w-full max-w-sm">
           <SphereCanvas compact />
         </div>
         <div className="relative z-10 mx-auto w-full px-6 pt-4 pb-4 text-center">

--- a/components/Hero2.tsx
+++ b/components/Hero2.tsx
@@ -1,0 +1,78 @@
+// components/Hero2.tsx
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import SphereCanvas from "@/components/SphereCanvas";
+
+export default function Hero2() {
+  const prefersReduced = useReducedMotion();
+
+  return (
+    <div>
+      {/* Mobile: small centered planet up top, text flows below in normal layout */}
+      <section className="relative md:hidden">
+        <div className="relative mx-auto mt-8 h-56 w-full max-w-xs">
+          <SphereCanvas compact />
+        </div>
+        <div className="relative z-10 mx-auto w-full px-6 pt-4 pb-4 text-center">
+          <motion.h1
+            className="text-4xl font-light leading-tight tracking-tight text-foreground"
+            initial={prefersReduced ? {} : { opacity: 0, y: 8 }}
+            animate={prefersReduced ? {} : { opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+          >
+            Hi, I&apos;m Meerav.
+          </motion.h1>
+
+          <motion.p
+            className="mt-4 text-sm text-muted leading-relaxed"
+            initial={prefersReduced ? {} : { opacity: 0, y: 6 }}
+            animate={prefersReduced ? {} : { opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: "easeOut", delay: 0.15 }}
+          >
+            Applied AI Engineer at Rolai.
+          </motion.p>
+        </div>
+      </section>
+
+      {/* Desktop: full-bleed sphere background, vertically centered content */}
+      <section className="relative hidden min-h-[calc(100vh-57px)] md:flex md:flex-col md:justify-center overflow-hidden">
+        <SphereCanvas />
+        <div className="relative z-10 mx-auto w-full max-w-3xl px-6 py-20">
+          <motion.h1
+            className="text-5xl md:text-7xl font-light leading-tight tracking-tight text-foreground"
+            initial={prefersReduced ? {} : { opacity: 0, y: 8 }}
+            animate={prefersReduced ? {} : { opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+          >
+            Hi, I&apos;m Meerav.
+          </motion.h1>
+
+          <motion.p
+            className="mt-4 text-sm text-muted leading-relaxed"
+            initial={prefersReduced ? {} : { opacity: 0, y: 6 }}
+            animate={prefersReduced ? {} : { opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: "easeOut", delay: 0.15 }}
+          >
+            Applied AI Engineer at Rolai.
+          </motion.p>
+
+          <motion.div
+            className="mt-8"
+            initial={prefersReduced ? {} : { opacity: 0 }}
+            animate={prefersReduced ? {} : { opacity: 1 }}
+            transition={{ delay: 0.35, duration: 0.5 }}
+          >
+            <a
+              href="#work"
+              className="inline-block text-xs text-muted/50 hover:text-muted transition-colors tracking-widest uppercase"
+              aria-label="Scroll to selected work"
+            >
+              ↓ Scroll
+            </a>
+          </motion.div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/SphereCanvas.tsx
+++ b/components/SphereCanvas.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTheme } from "@/components/ThemeProvider";
+
+export default function SphereCanvas({ compact = false }: { compact?: boolean }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const isDark = theme === "dark";
+    // Start with satellite at front of orbit (sin≈1, fully visible) so it appears immediately
+    let t = (Math.PI / 2) / 0.55;
+
+    function resize() {
+      if (!canvas) return;
+      canvas.width  = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    }
+
+    function draw() {
+      if (!canvas || !ctx) return;
+      const W = canvas.width;
+      const H = canvas.height;
+      ctx.clearRect(0, 0, W, H);
+
+      // ── Main sphere ──────────────────────────────────────
+      // Compact mode: centered sphere, radius fit to the smaller dimension so
+      // the sphere + satellite orbit (which extends to R*1.38 either side)
+      // stays inside a roughly square box instead of a wide letterboxed one.
+      const R  = compact ? Math.min(W, H) * 0.34 : H * 0.58;
+      const cx = compact ? W * 0.5 : W - R * 0.22;
+      const cy = H * 0.50;
+
+      // 1. Body gradient
+      const body = ctx.createRadialGradient(
+        cx - R * 0.32, cy - R * 0.28, R * 0.02,
+        cx + R * 0.12, cy + R * 0.18, R
+      );
+      if (isDark) {
+        body.addColorStop(0,    "rgba(115,115,135,1)");
+        body.addColorStop(0.35, "rgba(55,55,68,1)");
+        body.addColorStop(0.75, "rgba(18,18,24,1)");
+        body.addColorStop(1,    "rgba(6,6,9,1)");
+      } else {
+        body.addColorStop(0,    "rgba(245,245,250,1)");
+        body.addColorStop(0.35, "rgba(195,195,208,1)");
+        body.addColorStop(0.75, "rgba(140,140,155,1)");
+        body.addColorStop(1,    "rgba(90,90,105,1)");
+      }
+      ctx.beginPath();
+      ctx.arc(cx, cy, R, 0, Math.PI * 2);
+      ctx.fillStyle = body;
+      ctx.fill();
+
+      // Clip for layers 2–4
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(cx, cy, R, 0, Math.PI * 2);
+      ctx.clip();
+
+      // 2. Rotating surface band
+      const bx = cx + R * 0.55 * Math.cos(t * 0.4);
+      const by = cy + R * 0.25 * Math.sin(t * 0.28);
+      const band = ctx.createRadialGradient(bx, by, 0, bx, by, R * 0.95);
+      band.addColorStop(0, isDark ? "rgba(255,255,255,0.04)" : "rgba(255,255,255,0.15)");
+      band.addColorStop(1, isDark ? "rgba(0,0,0,0.22)"      : "rgba(0,0,0,0.08)");
+      ctx.fillStyle = band;
+      ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+
+      // 3. Specular highlight
+      const spec = ctx.createRadialGradient(
+        cx - R * 0.36, cy - R * 0.36, 0,
+        cx - R * 0.14, cy - R * 0.14, R * 0.5
+      );
+      spec.addColorStop(0,   isDark ? "rgba(255,255,255,0.28)" : "rgba(255,255,255,0.85)");
+      spec.addColorStop(0.5, isDark ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.20)");
+      spec.addColorStop(1,   "rgba(255,255,255,0)");
+      ctx.fillStyle = spec;
+      ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+
+      // 4. Shadow
+      const shadow = ctx.createRadialGradient(
+        cx + R * 0.38, cy + R * 0.38, 0,
+        cx + R * 0.15, cy + R * 0.15, R * 0.9
+      );
+      shadow.addColorStop(0, isDark ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.20)");
+      shadow.addColorStop(1, "rgba(0,0,0,0)");
+      ctx.fillStyle = shadow;
+      ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+
+      ctx.restore();
+
+      // Atmosphere rim
+      const rim = ctx.createRadialGradient(cx, cy, R * 0.82, cx, cy, R * 1.10);
+      rim.addColorStop(0,    "rgba(160,170,220,0)");
+      rim.addColorStop(0.75, isDark ? "rgba(160,170,220,0.05)" : "rgba(160,170,220,0.08)");
+      rim.addColorStop(1,    isDark ? "rgba(160,170,220,0.12)" : "rgba(160,170,220,0.18)");
+      ctx.beginPath();
+      ctx.arc(cx, cy, R * 1.10, 0, Math.PI * 2);
+      ctx.fillStyle = rim;
+      ctx.fill();
+
+      // ── Satellite orbit ───────────────────────────────────
+      const orbitRx    = R * 1.38;
+      const orbitRy    = R * 0.40;
+      const orbitTilt  = -0.48;
+      const orbitAngle = t * 0.55;
+
+      const rawX = orbitRx * Math.cos(orbitAngle);
+      const rawY = orbitRy * Math.sin(orbitAngle);
+      const satX = cx + rawX * Math.cos(orbitTilt) - rawY * Math.sin(orbitTilt);
+      const satY = cy + rawX * Math.sin(orbitTilt) + rawY * Math.cos(orbitTilt);
+      // sin: -1 = fully behind, +1 = fully in front → map to [0.15, 1.0]
+      const sinVal   = Math.sin(orbitAngle);
+      const satAlpha = 0.15 + 0.85 * ((sinVal + 1) / 2);
+      const isBehind = sinVal < 0;
+
+      // Orbit ring
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(orbitTilt);
+      ctx.scale(1, orbitRy / orbitRx);
+      ctx.setLineDash([3, 9]);
+      ctx.strokeStyle = isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.09)";
+      ctx.lineWidth = 0.9 * (orbitRx / orbitRy);
+      ctx.beginPath();
+      ctx.arc(0, 0, orbitRx, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+
+      // Satellite — flat, cool grey, continuous alpha
+      const sr = R * 0.072;
+      const satFill = isDark
+        ? `rgba(175,178,188,${satAlpha})`
+        : `rgba(108,110,118,${satAlpha})`;
+
+      ctx.beginPath();
+      ctx.arc(satX, satY, sr, 0, Math.PI * 2);
+      ctx.fillStyle = satFill;
+      ctx.fill();
+
+      // Redraw main sphere on top when satellite is behind for occlusion
+      if (isBehind) {
+        const bodyAgain = ctx.createRadialGradient(
+          cx - R * 0.32, cy - R * 0.28, R * 0.02,
+          cx + R * 0.12, cy + R * 0.18, R
+        );
+        if (isDark) {
+          bodyAgain.addColorStop(0,    "rgba(115,115,135,1)");
+          bodyAgain.addColorStop(0.35, "rgba(55,55,68,1)");
+          bodyAgain.addColorStop(0.75, "rgba(18,18,24,1)");
+          bodyAgain.addColorStop(1,    "rgba(6,6,9,1)");
+        } else {
+          bodyAgain.addColorStop(0,    "rgba(245,245,250,1)");
+          bodyAgain.addColorStop(0.35, "rgba(195,195,208,1)");
+          bodyAgain.addColorStop(0.75, "rgba(140,140,155,1)");
+          bodyAgain.addColorStop(1,    "rgba(90,90,105,1)");
+        }
+        ctx.beginPath();
+        ctx.arc(cx, cy, R, 0, Math.PI * 2);
+        ctx.fillStyle = bodyAgain;
+        ctx.fill();
+
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, R, 0, Math.PI * 2);
+        ctx.clip();
+        ctx.fillStyle = spec;
+        ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+        ctx.fillStyle = shadow;
+        ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+        ctx.restore();
+      }
+    }
+
+    function tick() {
+      t += 0.005;
+      draw();
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    const ro = new ResizeObserver(() => { resize(); draw(); });
+    ro.observe(canvas);
+    resize();
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      ro.disconnect();
+    };
+  }, [theme, compact]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="absolute inset-0 w-full h-full"
+    />
+  );
+}

--- a/components/WorkRow.tsx
+++ b/components/WorkRow.tsx
@@ -1,0 +1,45 @@
+// components/WorkRow.tsx
+import { ArrowUpRight } from "lucide-react";
+import type { WorkItem } from "@/data/work";
+
+interface WorkRowProps {
+  item: WorkItem;
+  /** If true, render as an anchor tag; if false, render as a div */
+  linked?: boolean;
+}
+
+export function WorkRow({ item, linked = true }: WorkRowProps) {
+  const inner = (
+    <div className="group flex items-start gap-4 py-5 border-t border-border">
+      <div className="w-0.5 min-h-[2.5rem] bg-border rounded-full shrink-0 mt-1" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium text-foreground leading-snug">{item.org}</p>
+            <p className="text-xs text-muted mt-0.5">{item.role}</p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-xs text-muted/60 tabular-nums whitespace-nowrap">{item.period}</span>
+            {item.link && (
+              <ArrowUpRight
+                size={13}
+                className="text-muted/40 group-hover:text-muted transition-colors"
+              />
+            )}
+          </div>
+        </div>
+        <p className="mt-2 text-sm text-muted leading-relaxed">{item.description}</p>
+      </div>
+    </div>
+  );
+
+  if (linked && item.link) {
+    return (
+      <a href={item.link} target="_blank" rel="noopener noreferrer" className="block hover:bg-card/40 transition-colors rounded-sm -mx-2 px-2">
+        {inner}
+      </a>
+    );
+  }
+
+  return <div className="rounded-sm -mx-2 px-2 hover:bg-card/40 transition-colors">{inner}</div>;
+}

--- a/data/work.ts
+++ b/data/work.ts
@@ -1,0 +1,140 @@
+// data/work.ts
+
+export type WorkItem = {
+  id: string;
+  period: string;          // e.g. "Jun 2025 – Present"
+  org: string;             // company or institution
+  role: string;            // job title or researcher role
+  description: string;     // 1–2 sentences, plain prose
+  link?: string;           // optional external or internal URL
+  featured?: boolean;      // true = show on home page
+  category: "industry" | "research" | "early";
+};
+
+export const workItems: WorkItem[] = [
+  // ── Industry ──────────────────────────────────────────────────────────────
+  {
+    id: "rolai-engineer",
+    period: "Jun 2026–Present",
+    org: "Rolai",
+    role: "Applied AI Engineer",
+    description: "🚀",
+    featured: true,
+    category: "industry",
+  },
+  {
+    id: "rolai-intern",
+    period: "Sep 2025–Jun 2026",
+    org: "Rolai",
+    role: "AI Engineering Intern",
+    description:
+      "Built & deployed 32+ client-facing AI solutions on the Rolai platform; engineered Monday.com integration bringing 130+ API actions to end users; improved delivery time 20%.",
+    featured: true,
+    category: "industry",
+  },
+  {
+    id: "rolai-research",
+    period: "Jun–Aug 2025",
+    org: "Rolai",
+    role: "Applied Research Intern",
+    description:
+      "Deployed an academic advising chatbot with live web-scraping, reducing content maintenance ~50%. Co-authored 3 white papers on AI in education; developed 45 AI automation use-cases.",
+    category: "industry",
+  },
+  {
+    id: "psu-avt",
+    period: "Jan–Mar 2026",
+    org: "Penn State Advanced Vehicle Team",
+    role: "Perception Engineer",
+    description:
+      "Refactored LiDAR–camera depth fusion pipeline to ±0.2m accuracy — 60% beyond spec. Implemented unit testing in ROS2-based perception stack.",
+    category: "industry",
+  },
+  {
+    id: "perplexity",
+    period: "Aug 2024–May 2025",
+    org: "Perplexity",
+    role: "Campus Strategist",
+    description:
+      "Grew Penn State to 774 sign-ups. Planned and organized campus PR events for Perplexity.ai.",
+    category: "industry",
+  },
+
+  // ── Research & Leadership ─────────────────────────────────────────────────
+  {
+    id: "ist-research",
+    period: "Jun 2024–Jun 2026",
+    org: "College of IST, Penn State",
+    role: "Undergraduate Research Assistant",
+    description:
+      "Built LLM-powered academic advising chatbot reducing advising load 35%. Published at ACM SIGCSE 2025.",
+    link: "https://dl.acm.org/doi/10.1145/3641555.3705026",
+    category: "research",
+  },
+  {
+    id: "uav-icing",
+    period: "Jun–Jul 2024",
+    org: "Penn State College of Engineering (MC REU)",
+    role: "Researcher",
+    description:
+      "Investigated UAV icing detection using torque and RPM loss signals. Presented at ASEE MidAtlantic 2025.",
+    link: "https://sites.google.com/psu.edu/meeravshah/mc-reu-research",
+    category: "research",
+  },
+  {
+    id: "av-research",
+    period: "Aug 2023–May 2024",
+    org: "Penn State Research",
+    role: "Undergraduate Researcher",
+    description:
+      "Driving simulator study on human–AV interaction using STISIM3. Built 4 road scenarios to test driver behavior around autonomous vehicles.",
+    category: "research",
+  },
+  {
+    id: "nasa-big-idea",
+    period: "Oct 2023–May 2024",
+    org: "NASA BIG Idea Challenge — SSPL",
+    role: "Team Lead & Researcher",
+    description:
+      "Led 15-person team on lunar regolith 3D printing system — inflatable dome enclosing a robotic arm 3D printer, fully self-deployed.",
+    category: "research",
+  },
+  {
+    id: "ist-la",
+    period: "Jan 2024–May 2025",
+    org: "Penn State College of IST",
+    role: "Lead Learning Assistant",
+    description:
+      "Led team of 14 LAs for IST 130 (AI & Art). Managed grading, operations, correspondence. Curated 50+ AI tools for 500+ students.",
+    category: "research",
+  },
+
+  // ── Early Projects ────────────────────────────────────────────────────────
+  {
+    id: "lirem",
+    period: "2020",
+    org: "Lirem",
+    role: "Founder",
+    description:
+      "Launched a neighborhood reading program; grew city-wide volunteer network until COVID halted ops. Learned ownership, rapid decision-making, and validation.",
+    category: "early",
+  },
+  {
+    id: "code-warriors",
+    period: "Jun 2020–Jun 2021",
+    org: "Code Warriors Club, DPS Bopal",
+    role: "Director",
+    description:
+      "Grew club to 100+ members during COVID by going fully online. Ran Technovanza — city-wide tech-fest with 1,000+ attendees.",
+    category: "early",
+  },
+  {
+    id: "electrobotic",
+    period: "Sep–Oct 2019",
+    org: "Electrobotic Manufacturing",
+    role: "Intern",
+    description:
+      "Built AWD robot with 4-axis arm. Led team to national finals at Nirma University Robocon — ranked 9th overall.",
+    category: "early",
+  },
+];


### PR DESCRIPTION
## Summary
- Replaces the homepage with the redesigned hero (large centered animated planet), selected-work rows, and contact section from the overhaul branch
- Adds `/work`, the full career timeline page linked from "All work →"
- Enlarges and vertically centers the mobile hero planet so it fills the above-the-fold view like the desktop version

## Scope
Only the landing page and its dependencies are included — Header/nav, sidequests listing, theme toggle styling, and other pages are untouched. A snapshot of the pre-merge `main` is saved at `main-backup`.

## Test plan
- [x] `npm run build` passes cleanly
- [x] Verified `/` and `/work` render correctly in dev server (no console errors)
- [x] Confirmed mobile hero sizing via computed layout metrics (sphere diameter ~152px → ~217px, vertically centered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)