### PR TITLE
Update Rolai role blurb, default to light mode, simplify sidequests filters

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-background text-foreground selection:bg-accent">
         <ThemeProvider>
           <Header />

--- a/app/sidequests/[slug]/page.tsx
+++ b/app/sidequests/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/sidequests";
 import { PostHeader } from "@/components/sidequests/PostHeader";
 import { Prose } from "@/components/sidequests/Prose";
+import { Breadcrumbs } from "@/components/sidequests/Breadcrumbs";
 import Link from "next/link";
 
 export async function generateMetadata({
@@ -35,6 +36,9 @@ export default async function SidequestPage({
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-14">
+      <Breadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Sidequests", href: "/sidequests" }, { label: post.title }]}
+      />
       <PostHeader post={post} />
       <Prose>{post.body}</Prose>
       <div className="mt-8 flex justify-between text-sm">

--- a/app/sidequests/page.tsx
+++ b/app/sidequests/page.tsx
@@ -10,6 +10,7 @@ import { Filters } from "@/components/sidequests/Filters";
 import { SidequestCard } from "@/components/sidequests/SidequestCard";
 import { EmptyState } from "@/components/sidequests/EmptyState";
 import { Pagination } from "@/components/sidequests/Pagination";
+import { Breadcrumbs } from "@/components/sidequests/Breadcrumbs";
 
 export const metadata: Metadata = {
   title: "Sidequests — Meerav Shah",
@@ -39,6 +40,7 @@ export default function Page({
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-14">
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Sidequests" }]} />
       <h1 className="text-3xl font-semibold">Sidequests</h1>
       <p className="text-muted mb-6">Explorations off the main path.</p>
       <Filters tags={tags} />

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -10,7 +10,7 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: "dark",
+  theme: "light",
   toggleTheme: () => {},
 });
 
@@ -19,12 +19,12 @@ export function useTheme() {
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
     const mql = window.matchMedia("(prefers-color-scheme: dark)");
     const stored = window.localStorage.getItem("theme") as Theme | null;
-    const initial: Theme = stored || "dark";
+    const initial: Theme = stored || "light";
     setTheme(initial);
     document.documentElement.classList.toggle("dark", initial === "dark");
 

--- a/components/sidequests/Breadcrumbs.tsx
+++ b/components/sidequests/Breadcrumbs.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+export function Breadcrumbs({ items }: { items: { label: string; href?: string }[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6 flex items-center gap-1.5 text-sm text-muted">
+      {items.map((item, i) => (
+        <span key={i} className="flex items-center gap-1.5">
+          {i > 0 && <ChevronRight size={14} className="text-muted/50" aria-hidden="true" />}
+          {item.href ? (
+            <Link href={item.href} className="hover:text-foreground transition-colors">
+              {item.label}
+            </Link>
+          ) : (
+            <span className="text-foreground">{item.label}</span>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/components/sidequests/Filters.tsx
+++ b/components/sidequests/Filters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 export function Filters({
   tags,
@@ -10,16 +9,8 @@ export function Filters({
 }) {
   const router = useRouter();
   const params = useSearchParams();
-  const [search, setSearch] = useState(params.get("q") ?? "");
   const selected = new Set(params.getAll("tag"));
-  const mode = params.get("mode") === "OR" ? "OR" : "AND";
-
-  function updateParam(key: string, value?: string) {
-    const query = new URLSearchParams(params.toString());
-    if (!value) query.delete(key);
-    else query.set(key, value);
-    router.push(`/sidequests?${query.toString()}`);
-  }
+  const topTags = [...tags].sort((a, b) => b.count - a.count).slice(0, 2);
 
   function toggleTag(tag: string) {
     const query = new URLSearchParams(params.toString());
@@ -34,54 +25,24 @@ export function Filters({
     router.push(`/sidequests?${query.toString()}`);
   }
 
-  function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    updateParam("q", search || undefined);
-  }
+  if (!topTags.length) return null;
 
   return (
-    <form onSubmit={onSubmit} className="mb-6 space-y-2">
-      <div className="flex gap-2">
-        <input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search"
-          className="flex-1 rounded border px-2 py-1"
-        />
-        <button type="submit" className="rounded border px-3 py-1">
-          Go
-        </button>
+    <div className="mb-6 flex flex-wrap gap-2">
+      {topTags.map((t) => (
         <button
+          key={t.tag}
           type="button"
-          className="rounded border px-3 py-1"
-          onClick={() => router.push("/sidequests")}
+          onClick={() => toggleTag(t.tag)}
+          className={
+            selected.has(t.tag)
+              ? "px-2 py-0.5 rounded-full border bg-accent text-sm"
+              : "px-2 py-0.5 rounded-full border text-sm"
+          }
         >
-          Clear
+          {t.tag}
         </button>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {tags.map((t) => (
-          <button
-            key={t.tag}
-            type="button"
-            onClick={() => toggleTag(t.tag)}
-            className={
-              selected.has(t.tag)
-                ? "px-2 py-0.5 rounded-full border bg-accent text-sm"
-                : "px-2 py-0.5 rounded-full border text-sm"
-            }
-          >
-            {t.tag}
-          </button>
-        ))}
-        <button
-          type="button"
-          onClick={() => updateParam("mode", mode === "AND" ? "OR" : "AND")}
-          className="px-2 py-0.5 rounded-full border text-sm"
-        >
-          Mode: {mode}
-        </button>
-      </div>
-    </form>
+      ))}
+    </div>
   );
 }

--- a/data/work.ts
+++ b/data/work.ts
@@ -18,7 +18,7 @@ export const workItems: WorkItem[] = [
     period: "Jun 2026–Present",
     org: "Rolai",
     role: "Applied AI Engineer",
-    description: "🚀",
+    description: "Leading development of new product offering :)",
     featured: true,
     category: "industry",
   },


### PR DESCRIPTION
## Summary
- Replace the placeholder rocket emoji with a real description for the current Applied AI Engineer role at Rolai (matches latest LinkedIn info); flows through to both the homepage and `/work` since they share `data/work.ts`
- Make light the default theme site-wide, both for first paint (`app/layout.tsx`) and for visitors with no stored preference (`ThemeProvider`)
- Simplify `/sidequests`: remove the search bar, cap the tag filter bar at the 2 most common tags, and add breadcrumbs to the listing and individual post pages

## Test plan
- [x] `npm run build` passes cleanly
- [x] Verified in dev server: homepage renders light mode by default (no `dark` class, light background) and shows the updated Rolai description
- [x] Verified `/sidequests`: no search input, exactly 2 filter pills, breadcrumb renders
- [x] Verified an individual post page shows breadcrumbs

## Note
Found a pre-existing, unrelated bug while testing `/sidequests` — `SidequestCard` nests an anchor (`TagPill`) inside another anchor (the card link), which is invalid HTML and throws a hydration error on every load. Not touched here; flagged separately for a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)